### PR TITLE
chore: add prettier configuration and format codebase

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,0 +1,8 @@
+{
+  "semi": true,
+  "trailingComma": "es5",
+  "singleQuote": false,
+  "printWidth": 80,
+  "tabWidth": 2,
+  "arrowParens": "avoid"
+}

--- a/package.json
+++ b/package.json
@@ -7,6 +7,8 @@
     "build": "tsc --noEmit",
     "clean": "rm -rf dist",
     "dev": "bun run --watch src/index.ts",
+    "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
+    "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",
     "lint": "eslint --format unix ./src  --max-warnings=0",
     "lint:fix": "eslint --format unix ./src  --max-warnings=0 --fix",
     "start": "bun run src/index.ts",

--- a/src/api/github-client.ts
+++ b/src/api/github-client.ts
@@ -16,7 +16,7 @@ export async function githubFetch(path: string): Promise<any> {
 
   if (!response.ok) {
     throw new Error(
-      `GitHub API error: ${response.status} ${response.statusText}`,
+      `GitHub API error: ${response.status} ${response.statusText}`
     );
   }
 
@@ -34,14 +34,14 @@ export async function validateRepo(repo: string): Promise<boolean> {
 
 export async function getIssue(
   repo: string,
-  issueNumber: string,
+  issueNumber: string
 ): Promise<GitHubIssue> {
   return githubFetch(`/repos/${repo}/issues/${issueNumber}`);
 }
 
 export async function getPullRequest(
   repo: string,
-  prNumber: string,
+  prNumber: string
 ): Promise<GitHubPullRequest> {
   return githubFetch(`/repos/${repo}/pulls/${prNumber}`);
 }

--- a/src/handlers/gh-issue-handler.ts
+++ b/src/handlers/gh-issue-handler.ts
@@ -9,14 +9,14 @@ interface GhIssueEvent {
 
 export async function handleGhIssue(
   handler: BotHandler,
-  event: GhIssueEvent,
+  event: GhIssueEvent
 ): Promise<void> {
   const { channelId, args } = event;
 
   if (args.length < 2) {
     await handler.sendMessage(
       channelId,
-      "❌ Usage: `/gh_issue owner/repo #123` or `/gh_issue owner/repo 123`",
+      "❌ Usage: `/gh_issue owner/repo #123` or `/gh_issue owner/repo 123`"
     );
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -10,7 +10,7 @@ const bot = await makeTownsBot(
   process.env.JWT_SECRET!,
   {
     commands,
-  },
+  }
 );
 
 // ============================================================================
@@ -38,7 +38,7 @@ async function githubFetch(path: string) {
 
   if (!response.ok) {
     throw new Error(
-      `GitHub API error: ${response.status} ${response.statusText}`,
+      `GitHub API error: ${response.status} ${response.statusText}`
     );
   }
 
@@ -239,7 +239,7 @@ bot.onSlashCommand("help", async (handler, { channelId }) => {
       "• `/gh_issue owner/repo #123` - Show issue details\n\n" +
       "**Other Commands:**\n" +
       "• `/help` - Show this help message\n" +
-      "• `/time` - Get the current time",
+      "• `/time` - Get the current time"
   );
 });
 
@@ -258,7 +258,7 @@ bot.onSlashCommand("github", async (handler, event) => {
       "**Usage:**\n" +
         "• `/github subscribe owner/repo`\n" +
         "• `/github unsubscribe`\n" +
-        "• `/github status`",
+        "• `/github status`"
     );
     return;
   }
@@ -268,7 +268,7 @@ bot.onSlashCommand("github", async (handler, event) => {
       if (!repo) {
         await handler.sendMessage(
           channelId,
-          "❌ Usage: `/github subscribe owner/repo`",
+          "❌ Usage: `/github subscribe owner/repo`"
         );
         return;
       }
@@ -277,7 +277,7 @@ bot.onSlashCommand("github", async (handler, event) => {
       if (!repo.includes("/") || repo.split("/").length !== 2) {
         await handler.sendMessage(
           channelId,
-          "❌ Invalid format. Use: `owner/repo` (e.g., `facebook/react`)",
+          "❌ Invalid format. Use: `owner/repo` (e.g., `facebook/react`)"
         );
         return;
       }
@@ -287,7 +287,7 @@ bot.onSlashCommand("github", async (handler, event) => {
       if (!isValid) {
         await handler.sendMessage(
           channelId,
-          `❌ Repository **${repo}** not found or is not public`,
+          `❌ Repository **${repo}** not found or is not public`
         );
         return;
       }
@@ -313,7 +313,7 @@ bot.onSlashCommand("github", async (handler, event) => {
           `4. Secret: (set GITHUB_WEBHOOK_SECRET in your bot)\n` +
           `5. Events: Choose individual events or "Send me everything"\n` +
           `6. Click "Add webhook"\n\n` +
-          `_Note: You need write access to the repository to add webhooks._`,
+          `_Note: You need write access to the repository to add webhooks._`
       );
       break;
     }
@@ -323,7 +323,7 @@ bot.onSlashCommand("github", async (handler, event) => {
       if (!repos || repos.size === 0) {
         await handler.sendMessage(
           channelId,
-          "❌ This channel has no subscriptions",
+          "❌ This channel has no subscriptions"
         );
         return;
       }
@@ -344,7 +344,7 @@ bot.onSlashCommand("github", async (handler, event) => {
 
       await handler.sendMessage(
         channelId,
-        "✅ Unsubscribed from all repositories",
+        "✅ Unsubscribed from all repositories"
       );
       break;
     }
@@ -354,18 +354,18 @@ bot.onSlashCommand("github", async (handler, event) => {
       if (!repos || repos.size === 0) {
         await handler.sendMessage(
           channelId,
-          "📭 **No subscriptions**\n\nUse `/github subscribe owner/repo` to get started",
+          "📭 **No subscriptions**\n\nUse `/github subscribe owner/repo` to get started"
         );
         return;
       }
 
       const repoList = Array.from(repos)
-        .map((r) => `• ${r}`)
+        .map(r => `• ${r}`)
         .join("\n");
 
       await handler.sendMessage(
         channelId,
-        `📬 **Subscribed Repositories:**\n\n${repoList}`,
+        `📬 **Subscribed Repositories:**\n\n${repoList}`
       );
       break;
     }
@@ -377,7 +377,7 @@ bot.onSlashCommand("github", async (handler, event) => {
           "**Available actions:**\n" +
           "• `subscribe`\n" +
           "• `unsubscribe`\n" +
-          "• `status`",
+          "• `status`"
       );
   }
 });
@@ -388,7 +388,7 @@ bot.onSlashCommand("gh_pr", async (handler, event) => {
   if (args.length < 2) {
     await handler.sendMessage(
       channelId,
-      "❌ Usage: `/gh_pr owner/repo #123` or `/gh_pr owner/repo 123`",
+      "❌ Usage: `/gh_pr owner/repo #123` or `/gh_pr owner/repo 123`"
     );
     return;
   }
@@ -434,7 +434,7 @@ bot.onMessage(async (handler, { message, channelId }) => {
       try {
         const endpoint = type === "pull" ? "pulls" : "issues";
         const data = await githubFetch(
-          `/repos/${owner}/${repo}/${endpoint}/${number}`,
+          `/repos/${owner}/${repo}/${endpoint}/${number}`
         );
 
         const unfurled =
@@ -462,7 +462,7 @@ app.use(logger());
 app.post("/webhook", jwtMiddleware, handler);
 
 // GitHub webhook endpoint
-app.post("/github-webhook", async (c) => {
+app.post("/github-webhook", async c => {
   const signature = c.req.header("X-Hub-Signature-256");
   const event = c.req.header("X-GitHub-Event");
   const body = await c.req.text();
@@ -533,7 +533,7 @@ app.post("/github-webhook", async (c) => {
 });
 
 // Health check endpoint
-app.get("/health", (c) => {
+app.get("/health", c => {
   return c.json({
     status: "ok",
     subscriptions: channelToRepos.size,

--- a/tests/fixtures/mock-bot-handler.ts
+++ b/tests/fixtures/mock-bot-handler.ts
@@ -2,9 +2,7 @@ import type { BotHandler } from "@towns-protocol/bot";
 import { mock } from "bun:test";
 
 export function createMockBotHandler(): BotHandler {
-  const sendMessage = mock(() =>
-    Promise.resolve({ eventId: "test-event-id" }),
-  );
+  const sendMessage = mock(() => Promise.resolve({ eventId: "test-event-id" }));
   const editMessage = mock(() => Promise.resolve(undefined));
   const sendReaction = mock(() => Promise.resolve(undefined));
   const removeEvent = mock(() => Promise.resolve(undefined));

--- a/tests/integration/gh-issue-integration.test.ts
+++ b/tests/integration/gh-issue-integration.test.ts
@@ -29,7 +29,7 @@ describe("gh_issue handler - Integration", () => {
       console.error("GITHUB_TOKEN set:", !!process.env.GITHUB_TOKEN);
       console.error(
         "GITHUB_TOKEN length:",
-        process.env.GITHUB_TOKEN?.length || 0,
+        process.env.GITHUB_TOKEN?.length || 0
       );
     }
 

--- a/tests/unit/handlers/gh-issue-handler.test.ts
+++ b/tests/unit/handlers/gh-issue-handler.test.ts
@@ -25,7 +25,7 @@ describe("gh_issue handler", () => {
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Usage: `/gh_issue owner/repo #123` or `/gh_issue owner/repo 123`",
+      "❌ Usage: `/gh_issue owner/repo #123` or `/gh_issue owner/repo 123`"
     );
   });
 
@@ -38,13 +38,13 @@ describe("gh_issue handler", () => {
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Usage: `/gh_issue owner/repo #123` or `/gh_issue owner/repo 123`",
+      "❌ Usage: `/gh_issue owner/repo #123` or `/gh_issue owner/repo 123`"
     );
   });
 
   test("should fetch and display issue details with # prefix", async () => {
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      mockIssueResponse,
+      mockIssueResponse
     );
 
     await handleGhIssue(mockHandler, {
@@ -70,7 +70,7 @@ describe("gh_issue handler", () => {
 
   test("should fetch and display issue details without # prefix", async () => {
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      mockIssueResponse,
+      mockIssueResponse
     );
 
     await handleGhIssue(mockHandler, {
@@ -86,7 +86,7 @@ describe("gh_issue handler", () => {
 
   test("should display closed status for closed issues", async () => {
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      mockClosedIssueResponse,
+      mockClosedIssueResponse
     );
 
     await handleGhIssue(mockHandler, {
@@ -102,7 +102,7 @@ describe("gh_issue handler", () => {
 
   test("should omit labels line when no labels exist", async () => {
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      mockIssueWithoutLabelsResponse,
+      mockIssueWithoutLabelsResponse
     );
 
     await handleGhIssue(mockHandler, {
@@ -119,7 +119,7 @@ describe("gh_issue handler", () => {
   test("should handle GitHub API errors", async () => {
     const error = new Error("GitHub API error: 404 Not Found");
     const getIssueSpy = spyOn(githubClient, "getIssue").mockRejectedValue(
-      error,
+      error
     );
 
     await handleGhIssue(mockHandler, {
@@ -129,7 +129,7 @@ describe("gh_issue handler", () => {
 
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Error: GitHub API error: 404 Not Found",
+      "❌ Error: GitHub API error: 404 Not Found"
     );
 
     getIssueSpy.mockRestore();
@@ -138,7 +138,7 @@ describe("gh_issue handler", () => {
   test("should handle malformed repository names", async () => {
     const error = new Error("GitHub API error: 400 Bad Request");
     const getIssueSpy = spyOn(githubClient, "getIssue").mockRejectedValue(
-      error,
+      error
     );
 
     await handleGhIssue(mockHandler, {
@@ -148,7 +148,7 @@ describe("gh_issue handler", () => {
 
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Error: GitHub API error: 400 Bad Request",
+      "❌ Error: GitHub API error: 400 Bad Request"
     );
 
     getIssueSpy.mockRestore();
@@ -164,7 +164,7 @@ describe("gh_issue handler", () => {
       ],
     };
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      multiLabelIssue,
+      multiLabelIssue
     );
 
     await handleGhIssue(mockHandler, {
@@ -180,7 +180,7 @@ describe("gh_issue handler", () => {
 
   test("should strip markdown bold formatting from repo name", async () => {
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      mockIssueResponse,
+      mockIssueResponse
     );
 
     await handleGhIssue(mockHandler, {
@@ -195,7 +195,7 @@ describe("gh_issue handler", () => {
 
   test("should strip markdown italic formatting from issue number", async () => {
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      mockIssueResponse,
+      mockIssueResponse
     );
 
     await handleGhIssue(mockHandler, {
@@ -210,7 +210,7 @@ describe("gh_issue handler", () => {
 
   test("should strip markdown code formatting from arguments", async () => {
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      mockIssueResponse,
+      mockIssueResponse
     );
 
     await handleGhIssue(mockHandler, {
@@ -225,7 +225,7 @@ describe("gh_issue handler", () => {
 
   test("should strip multiple markdown formats from arguments", async () => {
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      mockIssueResponse,
+      mockIssueResponse
     );
 
     await handleGhIssue(mockHandler, {
@@ -240,7 +240,7 @@ describe("gh_issue handler", () => {
 
   test("should preserve underscores in repo names", async () => {
     const getIssueSpy = spyOn(githubClient, "getIssue").mockResolvedValue(
-      mockIssueResponse,
+      mockIssueResponse
     );
 
     await handleGhIssue(mockHandler, {


### PR DESCRIPTION
Add Prettier for consistent code formatting with plugin:prettier/recommended:

- Add .prettierrc with ES5-compatible configuration
  - trailingComma: "es5" (objects/arrays only, not function params)
  - 80 char print width, 2 space indent
  - Double quotes, semicolons

- Add format scripts to package.json
  - format: Auto-format all TypeScript files
  - format:check: Verify formatting in CI

- Format entire codebase with Prettier
  - Remove trailing commas from function parameters (ES5 style)
  - Consistent formatting across all TypeScript files
  - Works seamlessly with ESLint via plugin:prettier/recommended

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude <noreply@anthropic.com>