### PR TITLE
refactor: extract GitHub event formatters to separate module

### DIFF
--- a/src/formatters/github-events.ts
+++ b/src/formatters/github-events.ts
@@ -1,0 +1,170 @@
+/**
+ * GitHub webhook event formatters
+ * Converts GitHub webhook payloads into human-readable messages for Towns channels
+ */
+
+export function formatPullRequest(payload: any): string {
+  const { action, pull_request, repository } = payload;
+
+  if (action === "opened") {
+    return (
+      `🔔 **Pull Request Opened**\n` +
+      `**${repository.full_name}** #${pull_request.number}\n\n` +
+      `**${pull_request.title}**\n` +
+      `👤 ${pull_request.user.login}\n` +
+      `📊 +${pull_request.additions || 0} -${pull_request.deletions || 0}\n` +
+      `🔗 ${pull_request.html_url}`
+    );
+  }
+
+  if (action === "closed" && pull_request.merged) {
+    return (
+      `✅ **Pull Request Merged**\n` +
+      `**${repository.full_name}** #${pull_request.number}\n\n` +
+      `**${pull_request.title}**\n` +
+      `👤 ${pull_request.user.login}\n` +
+      `🔗 ${pull_request.html_url}`
+    );
+  }
+
+  if (action === "closed" && !pull_request.merged) {
+    return (
+      `❌ **Pull Request Closed**\n` +
+      `**${repository.full_name}** #${pull_request.number}\n\n` +
+      `**${pull_request.title}**\n` +
+      `👤 ${pull_request.user.login}\n` +
+      `🔗 ${pull_request.html_url}`
+    );
+  }
+
+  return "";
+}
+
+export function formatIssue(payload: any): string {
+  const { action, issue, repository } = payload;
+
+  if (action === "opened") {
+    return (
+      `🐛 **Issue Opened**\n` +
+      `**${repository.full_name}** #${issue.number}\n\n` +
+      `**${issue.title}**\n` +
+      `👤 ${issue.user.login}\n` +
+      `🔗 ${issue.html_url}`
+    );
+  }
+
+  if (action === "closed") {
+    return (
+      `✅ **Issue Closed**\n` +
+      `**${repository.full_name}** #${issue.number}\n\n` +
+      `**${issue.title}**\n` +
+      `👤 ${issue.user.login}\n` +
+      `🔗 ${issue.html_url}`
+    );
+  }
+
+  return "";
+}
+
+export function formatPush(payload: any): string {
+  const { ref, commits, pusher, repository, compare } = payload;
+  const branch = ref.replace("refs/heads/", "");
+  const commitCount = commits?.length || 0;
+
+  if (commitCount === 0) return "";
+
+  let message =
+    `📦 **Push to ${repository.full_name}**\n` +
+    `🌿 Branch: \`${branch}\`\n` +
+    `👤 ${pusher.name}\n` +
+    `📝 ${commitCount} commit${commitCount > 1 ? "s" : ""}\n\n`;
+
+  // Show first 3 commits
+  const displayCommits = commits.slice(0, 3);
+  for (const commit of displayCommits) {
+    const shortSha = commit.id.substring(0, 7);
+    const shortMessage = commit.message.split("\n")[0].substring(0, 60);
+    message += `\`${shortSha}\` ${shortMessage}\n`;
+  }
+
+  if (commitCount > 3) {
+    message += `\n_... and ${commitCount - 3} more commit${commitCount - 3 > 1 ? "s" : ""}_\n`;
+  }
+
+  message += `\n🔗 ${compare}`;
+
+  return message;
+}
+
+export function formatRelease(payload: any): string {
+  const { action, release, repository } = payload;
+
+  if (action === "published") {
+    return (
+      `🚀 **Release Published**\n` +
+      `**${repository.full_name}** ${release.tag_name}\n\n` +
+      `**${release.name || release.tag_name}**\n` +
+      `👤 ${release.author.login}\n` +
+      `🔗 ${release.html_url}`
+    );
+  }
+
+  return "";
+}
+
+export function formatWorkflowRun(payload: any): string {
+  const { action, workflow_run, repository } = payload;
+
+  if (action === "completed") {
+    const emoji = workflow_run.conclusion === "success" ? "✅" : "❌";
+    const status = workflow_run.conclusion === "success" ? "Passed" : "Failed";
+
+    return (
+      `${emoji} **CI ${status}**\n` +
+      `**${repository.full_name}**\n` +
+      `🔧 ${workflow_run.name}\n` +
+      `🌿 ${workflow_run.head_branch}\n` +
+      `🔗 ${workflow_run.html_url}`
+    );
+  }
+
+  return "";
+}
+
+export function formatIssueComment(payload: any): string {
+  const { action, issue, comment, repository } = payload;
+
+  if (action === "created") {
+    const shortComment = comment.body.split("\n")[0].substring(0, 100);
+
+    return (
+      `💬 **New Comment on Issue #${issue.number}**\n` +
+      `**${repository.full_name}**\n\n` +
+      `"${shortComment}${comment.body.length > 100 ? "..." : ""}"\n` +
+      `👤 ${comment.user.login}\n` +
+      `🔗 ${comment.html_url}`
+    );
+  }
+
+  return "";
+}
+
+export function formatPullRequestReview(payload: any): string {
+  const { action, review, pull_request, repository } = payload;
+
+  if (action === "submitted") {
+    let emoji = "👀";
+    if (review.state === "approved") emoji = "✅";
+    if (review.state === "changes_requested") emoji = "🔄";
+
+    return (
+      `${emoji} **PR Review: ${review.state.replace("_", " ")}**\n` +
+      `**${repository.full_name}** #${pull_request.number}\n\n` +
+      `**${pull_request.title}**\n` +
+      `👤 ${review.user.login}\n` +
+      `🔗 ${review.html_url}`
+    );
+  }
+
+  return "";
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,6 +6,15 @@ import crypto from "node:crypto";
 import { handleGhIssue } from "./handlers/gh-issue-handler";
 import { handleGhPr } from "./handlers/gh-pr-handler";
 import { githubFetch, validateRepo } from "./api/github-client";
+import {
+  formatPullRequest,
+  formatIssue,
+  formatPush,
+  formatRelease,
+  formatWorkflowRun,
+  formatIssueComment,
+  formatPullRequestReview,
+} from "./formatters/github-events";
 
 const bot = await makeTownsBot(
   process.env.APP_PRIVATE_DATA!,
@@ -20,175 +29,6 @@ const bot = await makeTownsBot(
 // ============================================================================
 const channelToRepos = new Map<string, Set<string>>(); // channelId -> Set of "owner/repo"
 const repoToChannels = new Map<string, Set<string>>(); // "owner/repo" -> Set of channelIds
-
-// ============================================================================
-// GITHUB EVENT FORMATTERS
-// ============================================================================
-function formatPullRequest(payload: any): string {
-  const { action, pull_request, repository } = payload;
-
-  if (action === "opened") {
-    return (
-      `🔔 **Pull Request Opened**\n` +
-      `**${repository.full_name}** #${pull_request.number}\n\n` +
-      `**${pull_request.title}**\n` +
-      `👤 ${pull_request.user.login}\n` +
-      `📊 +${pull_request.additions || 0} -${pull_request.deletions || 0}\n` +
-      `🔗 ${pull_request.html_url}`
-    );
-  }
-
-  if (action === "closed" && pull_request.merged) {
-    return (
-      `✅ **Pull Request Merged**\n` +
-      `**${repository.full_name}** #${pull_request.number}\n\n` +
-      `**${pull_request.title}**\n` +
-      `👤 ${pull_request.user.login}\n` +
-      `🔗 ${pull_request.html_url}`
-    );
-  }
-
-  if (action === "closed" && !pull_request.merged) {
-    return (
-      `❌ **Pull Request Closed**\n` +
-      `**${repository.full_name}** #${pull_request.number}\n\n` +
-      `**${pull_request.title}**\n` +
-      `👤 ${pull_request.user.login}\n` +
-      `🔗 ${pull_request.html_url}`
-    );
-  }
-
-  return "";
-}
-
-function formatIssue(payload: any): string {
-  const { action, issue, repository } = payload;
-
-  if (action === "opened") {
-    return (
-      `🐛 **Issue Opened**\n` +
-      `**${repository.full_name}** #${issue.number}\n\n` +
-      `**${issue.title}**\n` +
-      `👤 ${issue.user.login}\n` +
-      `🔗 ${issue.html_url}`
-    );
-  }
-
-  if (action === "closed") {
-    return (
-      `✅ **Issue Closed**\n` +
-      `**${repository.full_name}** #${issue.number}\n\n` +
-      `**${issue.title}**\n` +
-      `👤 ${issue.user.login}\n` +
-      `🔗 ${issue.html_url}`
-    );
-  }
-
-  return "";
-}
-
-function formatPush(payload: any): string {
-  const { ref, commits, pusher, repository, compare } = payload;
-  const branch = ref.replace("refs/heads/", "");
-  const commitCount = commits?.length || 0;
-
-  if (commitCount === 0) return "";
-
-  let message =
-    `📦 **Push to ${repository.full_name}**\n` +
-    `🌿 Branch: \`${branch}\`\n` +
-    `👤 ${pusher.name}\n` +
-    `📝 ${commitCount} commit${commitCount > 1 ? "s" : ""}\n\n`;
-
-  // Show first 3 commits
-  const displayCommits = commits.slice(0, 3);
-  for (const commit of displayCommits) {
-    const shortSha = commit.id.substring(0, 7);
-    const shortMessage = commit.message.split("\n")[0].substring(0, 60);
-    message += `\`${shortSha}\` ${shortMessage}\n`;
-  }
-
-  if (commitCount > 3) {
-    message += `\n_... and ${commitCount - 3} more commit${commitCount - 3 > 1 ? "s" : ""}_\n`;
-  }
-
-  message += `\n🔗 ${compare}`;
-
-  return message;
-}
-
-function formatRelease(payload: any): string {
-  const { action, release, repository } = payload;
-
-  if (action === "published") {
-    return (
-      `🚀 **Release Published**\n` +
-      `**${repository.full_name}** ${release.tag_name}\n\n` +
-      `**${release.name || release.tag_name}**\n` +
-      `👤 ${release.author.login}\n` +
-      `🔗 ${release.html_url}`
-    );
-  }
-
-  return "";
-}
-
-function formatWorkflowRun(payload: any): string {
-  const { action, workflow_run, repository } = payload;
-
-  if (action === "completed") {
-    const emoji = workflow_run.conclusion === "success" ? "✅" : "❌";
-    const status = workflow_run.conclusion === "success" ? "Passed" : "Failed";
-
-    return (
-      `${emoji} **CI ${status}**\n` +
-      `**${repository.full_name}**\n` +
-      `🔧 ${workflow_run.name}\n` +
-      `🌿 ${workflow_run.head_branch}\n` +
-      `🔗 ${workflow_run.html_url}`
-    );
-  }
-
-  return "";
-}
-
-function formatIssueComment(payload: any): string {
-  const { action, issue, comment, repository } = payload;
-
-  if (action === "created") {
-    const shortComment = comment.body.split("\n")[0].substring(0, 100);
-
-    return (
-      `💬 **New Comment on Issue #${issue.number}**\n` +
-      `**${repository.full_name}**\n\n` +
-      `"${shortComment}${comment.body.length > 100 ? "..." : ""}"\n` +
-      `👤 ${comment.user.login}\n` +
-      `🔗 ${comment.html_url}`
-    );
-  }
-
-  return "";
-}
-
-function formatPullRequestReview(payload: any): string {
-  const { action, review, pull_request, repository } = payload;
-
-  if (action === "submitted") {
-    let emoji = "👀";
-    if (review.state === "approved") emoji = "✅";
-    if (review.state === "changes_requested") emoji = "🔄";
-
-    return (
-      `${emoji} **PR Review: ${review.state.replace("_", " ")}**\n` +
-      `**${repository.full_name}** #${pull_request.number}\n\n` +
-      `**${pull_request.title}**\n` +
-      `👤 ${review.user.login}\n` +
-      `🔗 ${review.html_url}`
-    );
-  }
-
-  return "";
-}
 
 // ============================================================================
 // SLASH COMMAND HANDLERS


### PR DESCRIPTION
## Summary
Extract all 7 GitHub webhook event formatters from monolithic `index.ts` into a dedicated module for better code organization.

## Changes
- **Created** `src/formatters/github-events.ts` with 7 formatter functions:
  - `formatPullRequest` - PR opened/merged/closed
  - `formatIssue` - Issue opened/closed
  - `formatPush` - Git push events with commit details
  - `formatRelease` - Release published
  - `formatWorkflowRun` - CI workflow pass/fail
  - `formatIssueComment` - New issue comments
  - `formatPullRequestReview` - PR review approved/changes requested

- **Updated** `src/index.ts`:
  - Removed ~200 lines of formatter code
  - Import formatters from centralized module
  - Maintains all existing functionality

## Benefits
✅ Better separation of concerns  
✅ Easier to test formatters in isolation (future work)  
✅ Reusable across different contexts  
✅ Smaller, more focused files  

## Testing
- All 33 existing tests still passing ✓
- No functional changes, pure refactoring

## Part of Modular Architecture Refactoring
Previous PRs:
- #3 Extract `gh_issue` handler
- #5 Extract `gh_pr` handler

🤖 Generated with [Claude Code](https://claude.com/claude-code)