### PR TITLE
feat: add description display to gh_issue and gh_pr commands

### DIFF
--- a/src/api/github-types.ts
+++ b/src/api/github-types.ts
@@ -12,6 +12,7 @@ export interface GitHubLabel {
 export interface GitHubIssue {
   number: number;
   title: string;
+  body: string | null;
   state: "open" | "closed";
   user: GitHubUser;
   comments: number;

--- a/src/handlers/gh-issue-handler.ts
+++ b/src/handlers/gh-issue-handler.ts
@@ -1,6 +1,7 @@
 import type { BotHandler } from "@towns-protocol/bot";
 import { getIssue } from "../api/github-client";
 import { stripMarkdown } from "../utils/stripper";
+import { truncateText } from "../utils/text";
 
 interface GhIssueEvent {
   channelId: string;
@@ -13,27 +14,37 @@ export async function handleGhIssue(
 ): Promise<void> {
   const { channelId, args } = event;
 
-  if (args.length < 2) {
+  // Check for --full flag
+  const hasFullFlag = args.includes("--full");
+  const cleanArgs = args.filter(arg => arg !== "--full");
+
+  if (cleanArgs.length < 2) {
     await handler.sendMessage(
       channelId,
-      "❌ Usage: `/gh_issue owner/repo #123` or `/gh_issue owner/repo 123`"
+      "❌ Usage: `/gh_issue owner/repo #123 [--full]` or `/gh_issue owner/repo 123 [--full]`"
     );
     return;
   }
 
   // Strip markdown formatting from arguments
-  const repo = stripMarkdown(args[0]);
-  const issueNumber = stripMarkdown(args[1]).replace("#", "");
+  const repo = stripMarkdown(cleanArgs[0]);
+  const issueNumber = stripMarkdown(cleanArgs[1]).replace("#", "");
 
   try {
     const issue = await getIssue(repo, issueNumber);
 
     const labels = issue.labels.map((l: any) => l.name).join(", ");
 
+    // Format description
+    const description = hasFullFlag
+      ? issue.body
+      : truncateText(issue.body, 100);
+
     const message =
       `**Issue #${issue.number}**\n` +
       `**${repo}**\n\n` +
       `**${issue.title}**\n\n` +
+      (description ? `${description}\n\n` : "") +
       `📊 Status: ${issue.state === "open" ? "🟢 Open" : "✅ Closed"}\n` +
       `👤 Author: ${issue.user.login}\n` +
       `💬 Comments: ${issue.comments}\n` +

--- a/src/handlers/gh-pr-handler.ts
+++ b/src/handlers/gh-pr-handler.ts
@@ -1,6 +1,7 @@
 import type { BotHandler } from "@towns-protocol/bot";
 import { getPullRequest } from "../api/github-client";
 import { stripMarkdown } from "../utils/stripper";
+import { truncateText } from "../utils/text";
 
 interface GhPrEvent {
   channelId: string;
@@ -13,25 +14,33 @@ export async function handleGhPr(
 ): Promise<void> {
   const { channelId, args } = event;
 
-  if (args.length < 2) {
+  // Check for --full flag
+  const hasFullFlag = args.includes("--full");
+  const cleanArgs = args.filter(arg => arg !== "--full");
+
+  if (cleanArgs.length < 2) {
     await handler.sendMessage(
       channelId,
-      "❌ Usage: `/gh_pr owner/repo #123` or `/gh_pr owner/repo 123`"
+      "❌ Usage: `/gh_pr owner/repo #123 [--full]` or `/gh_pr owner/repo 123 [--full]`"
     );
     return;
   }
 
   // Strip markdown formatting from arguments
-  const repo = stripMarkdown(args[0]);
-  const prNumber = stripMarkdown(args[1]).replace("#", "");
+  const repo = stripMarkdown(cleanArgs[0]);
+  const prNumber = stripMarkdown(cleanArgs[1]).replace("#", "");
 
   try {
     const pr = await getPullRequest(repo, prNumber);
+
+    // Format description
+    const description = hasFullFlag ? pr.body : truncateText(pr.body, 100);
 
     const message =
       `**Pull Request #${pr.number}**\n` +
       `**${repo}**\n\n` +
       `**${pr.title}**\n\n` +
+      (description ? `${description}\n\n` : "") +
       `📊 Status: ${pr.state === "open" ? "🟢 Open" : pr.merged ? "✅ Merged" : "❌ Closed"}\n` +
       `👤 Author: ${pr.user.login}\n` +
       `📝 Changes: +${pr.additions} -${pr.deletions}\n` +

--- a/src/index.ts
+++ b/src/index.ts
@@ -42,8 +42,9 @@ bot.onSlashCommand("help", async (handler, { channelId }) => {
       "• `/github unsubscribe` - Unsubscribe from all repos\n" +
       "• `/github status` - Show current subscriptions\n\n" +
       "**Query Commands:**\n" +
-      "• `/gh_pr owner/repo #123` - Show pull request details\n" +
-      "• `/gh_issue owner/repo #123` - Show issue details\n\n" +
+      "• `/gh_pr owner/repo #123 [--full]` - Show pull request details\n" +
+      "• `/gh_issue owner/repo #123 [--full]` - Show issue details\n" +
+      "• Add `--full` flag to show complete description\n\n" +
       "**Other Commands:**\n" +
       "• `/help` - Show this help message\n" +
       "• `/time` - Get the current time"

--- a/src/utils/text.ts
+++ b/src/utils/text.ts
@@ -1,0 +1,14 @@
+/**
+ * Truncate text to specified length and add ellipsis if needed
+ */
+export function truncateText(
+  text: string | null | undefined,
+  maxLength: number
+): string {
+  if (!text || text.trim() === "") return "";
+
+  const trimmed = text.trim();
+  if (trimmed.length <= maxLength) return trimmed;
+
+  return trimmed.substring(0, maxLength) + "...";
+}

--- a/tests/integration/gh-issue-integration.test.ts
+++ b/tests/integration/gh-issue-integration.test.ts
@@ -38,6 +38,11 @@ describe("gh_issue handler - Integration", () => {
     expect(message).toContain("**towns-protocol/towns**");
     expect(message).toContain("Bot building documentation"); // Real issue title
 
+    // Should contain the description (truncated to 100 chars)
+    expect(message).toContain(
+      "Is there any documentation on how to build bots for towns?"
+    );
+
     // Should have formatted fields
     expect(message).toContain("📊 Status:");
     expect(message).toContain("👤 Author:");

--- a/tests/integration/gh-pr-integration.test.ts
+++ b/tests/integration/gh-pr-integration.test.ts
@@ -7,12 +7,12 @@ import { createMockBotHandler } from "../fixtures/mock-bot-handler";
  * This test makes REAL API calls to GitHub to verify actual behavior
  */
 describe("gh_pr handler - Integration", () => {
-  test("should fetch real GitHub PR from towns-protocol/towns #4031", async () => {
+  test("should fetch real GitHub PR from towns-protocol/towns #4034", async () => {
     const mockHandler = createMockBotHandler();
 
     await handleGhPr(mockHandler, {
       channelId: "test-channel",
-      args: ["towns-protocol/towns", "#4031"],
+      args: ["towns-protocol/towns", "#4034"],
     });
 
     // Should have sent exactly one message
@@ -34,8 +34,11 @@ describe("gh_pr handler - Integration", () => {
     }
 
     // Should contain the actual PR data
-    expect(message).toContain("**Pull Request #4031**");
+    expect(message).toContain("**Pull Request #4034**");
     expect(message).toContain("**towns-protocol/towns**");
+
+    // Should contain the description (truncated to 100 chars)
+    expect(message).toContain("no need for this to be in two places");
 
     // Should have formatted fields
     expect(message).toContain("📊 Status:");

--- a/tests/unit/handlers/gh-issue-handler.test.ts
+++ b/tests/unit/handlers/gh-issue-handler.test.ts
@@ -25,7 +25,7 @@ describe("gh_issue handler", () => {
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Usage: `/gh_issue owner/repo #123` or `/gh_issue owner/repo 123`"
+      "❌ Usage: `/gh_issue owner/repo #123 [--full]` or `/gh_issue owner/repo 123 [--full]`"
     );
   });
 
@@ -38,7 +38,7 @@ describe("gh_issue handler", () => {
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Usage: `/gh_issue owner/repo #123` or `/gh_issue owner/repo 123`"
+      "❌ Usage: `/gh_issue owner/repo #123 [--full]` or `/gh_issue owner/repo 123 [--full]`"
     );
   });
 

--- a/tests/unit/handlers/gh-pr-handler.test.ts
+++ b/tests/unit/handlers/gh-pr-handler.test.ts
@@ -25,7 +25,7 @@ describe("gh_pr handler", () => {
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Usage: `/gh_pr owner/repo #123` or `/gh_pr owner/repo 123`"
+      "❌ Usage: `/gh_pr owner/repo #123 [--full]` or `/gh_pr owner/repo 123 [--full]`"
     );
   });
 
@@ -38,7 +38,7 @@ describe("gh_pr handler", () => {
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Usage: `/gh_pr owner/repo #123` or `/gh_pr owner/repo 123`"
+      "❌ Usage: `/gh_pr owner/repo #123 [--full]` or `/gh_pr owner/repo 123 [--full]`"
     );
   });
 


### PR DESCRIPTION
Add truncated description display (100 chars) with --full flag support:

- Update gh_issue handler
  - Show first 100 chars of issue body by default
  - Support --full flag for complete description
  - Handle null/empty descriptions gracefully

- Update gh_pr handler
  - Show first 100 chars of PR body by default
  - Support --full flag for complete description
  - Handle null/empty descriptions gracefully

- Add text utility (src/utils/text.ts)
  - truncateText() function for consistent truncation
  - Handles null/undefined input

- Update GitHub types
  - Add body: string | null to GitHubIssue interface
  - Better type safety for description handling

- Update tests
  - Fix usage message tests for --full flag
  - Update integration test to PR #4034 (has description body)
  - Verify actual description content is displayed
  - Test coverage: 33 pass, 81 expect() calls

- Update help text
  - Show [--full] flag in command examples
  - Document --full flag usage

Benefits:
- More context at a glance (truncated description)
- Full details available with --full flag
- No breaking changes to existing usage
- Gracefully handles missing descriptions

All 33 tests passing ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)