### PR TITLE
refactor: remove /time command and auto-unfurl feature

### DIFF
--- a/src/commands.ts
+++ b/src/commands.ts
@@ -6,10 +6,6 @@ const commands = [
     description: "Get help with bot commands",
   },
   {
-    name: "time",
-    description: "Get the current time",
-  },
-  {
     name: "github",
     description: "Manage GitHub subscriptions (subscribe, unsubscribe, status)",
   },


### PR DESCRIPTION
## Summary
Simplify bot by removing non-essential features:
- Remove `/time` command (handler, registration, help text)
- Remove auto-unfurl GitHub URLs feature (onMessage handler)
- Remove unused `githubFetch` import

## Benefits
- Simpler, more focused bot (GitHub integration only)
- Reduced code surface area
- Eliminates potential noise from auto-unfurling

## Changes
- `src/index.ts`: Removed `/time` handler and auto-unfurl message handler
- `src/commands.ts`: Removed `/time` command registration

🤖 Generated with [Claude Code](https://claude.com/claude-code)