### PR TITLE
feat: add slash commands for recent PRs and issues

### DIFF
--- a/src/api/github-client.ts
+++ b/src/api/github-client.ts
@@ -45,3 +45,21 @@ export async function getPullRequest(
 ): Promise<GitHubPullRequest> {
   return githubFetch(`/repos/${repo}/pulls/${prNumber}`);
 }
+
+export async function listPullRequests(
+  repo: string,
+  count: number = 10
+): Promise<GitHubPullRequest[]> {
+  return githubFetch(
+    `/repos/${repo}/pulls?state=all&per_page=${count}&sort=created&direction=desc`
+  );
+}
+
+export async function listIssues(
+  repo: string,
+  count: number = 10
+): Promise<GitHubIssue[]> {
+  return githubFetch(
+    `/repos/${repo}/issues?state=all&per_page=${count}&sort=created&direction=desc`
+  );
+}

--- a/src/api/github-types.ts
+++ b/src/api/github-types.ts
@@ -18,6 +18,7 @@ export interface GitHubIssue {
   comments: number;
   labels: GitHubLabel[];
   html_url: string;
+  pull_request?: any; // Present if this is actually a PR
   [key: string]: any;
 }
 

--- a/src/commands.ts
+++ b/src/commands.ts
@@ -18,6 +18,15 @@ const commands = [
     name: "gh_issue",
     description: "Show GitHub issue details (usage: /gh_issue owner/repo #123)",
   },
+  {
+    name: "gh_prs",
+    description:
+      "List recent pull requests (usage: /gh_prs owner/repo [count])",
+  },
+  {
+    name: "gh_issues",
+    description: "List recent issues (usage: /gh_issues owner/repo [count])",
+  },
 ] as const satisfies PlainMessage<SlashCommand>[];
 
 export default commands;

--- a/src/handlers/gh-issues-handler.ts
+++ b/src/handlers/gh-issues-handler.ts
@@ -1,0 +1,72 @@
+import type { BotHandler } from "@towns-protocol/bot";
+import { listIssues } from "../api/github-client";
+import { stripMarkdown } from "../utils/stripper";
+
+interface GhIssuesEvent {
+  channelId: string;
+  args: string[];
+}
+
+export async function handleGhIssues(
+  handler: BotHandler,
+  event: GhIssuesEvent
+): Promise<void> {
+  const { channelId, args } = event;
+
+  if (args.length < 1) {
+    await handler.sendMessage(
+      channelId,
+      "❌ Usage: `/gh_issues owner/repo [count]`\n\nExample: `/gh_issues facebook/react 5`"
+    );
+    return;
+  }
+
+  // Strip markdown formatting from arguments
+  const repo = stripMarkdown(args[0]);
+  const count = args[1] ? parseInt(args[1]) : 10;
+
+  if (isNaN(count) || count < 1 || count > 50) {
+    await handler.sendMessage(
+      channelId,
+      "❌ Count must be a number between 1 and 50"
+    );
+    return;
+  }
+
+  try {
+    const issues = await listIssues(repo, count);
+
+    if (issues.length === 0) {
+      await handler.sendMessage(channelId, `No issues found for **${repo}**`);
+      return;
+    }
+
+    // Filter out pull requests (GitHub API includes PRs in issues endpoint)
+    const actualIssues = issues.filter(issue => !issue.pull_request);
+
+    if (actualIssues.length === 0) {
+      await handler.sendMessage(
+        channelId,
+        `No issues found for **${repo}** (only PRs available)`
+      );
+      return;
+    }
+
+    const issueList = actualIssues
+      .map(issue => {
+        const status = issue.state === "open" ? "🟢 Open" : "✅ Closed";
+        const issueLink = `[#${issue.number}](${issue.html_url})`;
+        return `• ${issueLink} ${status} - **${issue.title}** by ${issue.user.login}`;
+      })
+      .join("\n");
+
+    const message =
+      `**Recent Issues - ${repo}**\n` +
+      `Showing ${actualIssues.length} most recent issues:\n\n` +
+      issueList;
+
+    await handler.sendMessage(channelId, message);
+  } catch (error: any) {
+    await handler.sendMessage(channelId, `❌ Error: ${error.message}`);
+  }
+}

--- a/src/handlers/gh-prs-handler.ts
+++ b/src/handlers/gh-prs-handler.ts
@@ -1,0 +1,69 @@
+import type { BotHandler } from "@towns-protocol/bot";
+import { listPullRequests } from "../api/github-client";
+import { stripMarkdown } from "../utils/stripper";
+
+interface GhPrsEvent {
+  channelId: string;
+  args: string[];
+}
+
+export async function handleGhPrs(
+  handler: BotHandler,
+  event: GhPrsEvent
+): Promise<void> {
+  const { channelId, args } = event;
+
+  if (args.length < 1) {
+    await handler.sendMessage(
+      channelId,
+      "❌ Usage: `/gh_prs owner/repo [count]`\n\nExample: `/gh_prs facebook/react 5`"
+    );
+    return;
+  }
+
+  // Strip markdown formatting from arguments
+  const repo = stripMarkdown(args[0]);
+  const count = args[1] ? parseInt(args[1]) : 10;
+
+  if (isNaN(count) || count < 1 || count > 50) {
+    await handler.sendMessage(
+      channelId,
+      "❌ Count must be a number between 1 and 50"
+    );
+    return;
+  }
+
+  try {
+    const prs = await listPullRequests(repo, count);
+
+    if (prs.length === 0) {
+      await handler.sendMessage(
+        channelId,
+        `No pull requests found for **${repo}**`
+      );
+      return;
+    }
+
+    const prList = prs
+      .map(pr => {
+        const status =
+          pr.state === "open"
+            ? "🟢 Open"
+            : pr.merged
+              ? "✅ Merged"
+              : "❌ Closed";
+        const prLink = `[#${pr.number}](${pr.html_url})`;
+        return `• ${prLink} ${status} - **${pr.title}** by ${pr.user.login}`;
+      })
+      .join("\n");
+
+    const message =
+      `**Recent Pull Requests - ${repo}**\n` +
+      `Showing ${prs.length} most recent PRs:\n\n` +
+      prList;
+
+    await handler.sendMessage(channelId, message);
+  } catch (error: any) {
+    await handler.sendMessage(channelId, `❌ Error: ${error.message}`);
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,6 +5,8 @@ import commands from "./commands";
 import crypto from "node:crypto";
 import { handleGhIssue } from "./handlers/gh-issue-handler";
 import { handleGhPr } from "./handlers/gh-pr-handler";
+import { handleGhPrs } from "./handlers/gh-prs-handler";
+import { handleGhIssues } from "./handlers/gh-issues-handler";
 import { handleGithubSubscription } from "./handlers/github-subscription-handler";
 import {
   formatPullRequest,
@@ -46,6 +48,8 @@ bot.onSlashCommand("help", async (handler, { channelId }) => {
       "**Query Commands:**\n" +
       "• `/gh_pr owner/repo #123 [--full]` - Show pull request details\n" +
       "• `/gh_issue owner/repo #123 [--full]` - Show issue details\n" +
+      "• `/gh_prs owner/repo [count]` - List recent pull requests (default: 10, max: 50)\n" +
+      "• `/gh_issues owner/repo [count]` - List recent issues (default: 10, max: 50)\n" +
       "• Add `--full` flag to show complete description\n\n" +
       "**Other Commands:**\n" +
       "• `/help` - Show this help message"
@@ -62,6 +66,10 @@ bot.onSlashCommand("github", async (handler, event) => {
 bot.onSlashCommand("gh_pr", handleGhPr);
 
 bot.onSlashCommand("gh_issue", handleGhIssue);
+
+bot.onSlashCommand("gh_prs", handleGhPrs);
+
+bot.onSlashCommand("gh_issues", handleGhIssues);
 
 // ============================================================================
 // START BOT & SETUP HONO APP

--- a/tests/fixtures/github-payloads.ts
+++ b/tests/fixtures/github-payloads.ts
@@ -47,3 +47,76 @@ export const mockClosedPullRequestResponse = {
   state: "closed" as const,
   merged: false,
 };
+
+export const mockPullRequestListResponse = [
+  {
+    number: 100,
+    title: "Add new feature X",
+    state: "open" as const,
+    merged: false,
+    user: { login: "developer1" },
+    html_url: "https://github.com/owner/repo/pull/100",
+  },
+  {
+    number: 99,
+    title: "Fix bug in component Y",
+    state: "closed" as const,
+    merged: true,
+    user: { login: "developer2" },
+    html_url: "https://github.com/owner/repo/pull/99",
+  },
+  {
+    number: 98,
+    title: "Update documentation",
+    state: "closed" as const,
+    merged: false,
+    user: { login: "developer3" },
+    html_url: "https://github.com/owner/repo/pull/98",
+  },
+];
+
+export const mockIssueListResponse = [
+  {
+    number: 50,
+    title: "Bug: App crashes on startup",
+    state: "open" as const,
+    user: { login: "user1" },
+    html_url: "https://github.com/owner/repo/issues/50",
+    labels: [{ name: "bug" }],
+  },
+  {
+    number: 49,
+    title: "Feature request: Add dark mode",
+    state: "open" as const,
+    user: { login: "user2" },
+    html_url: "https://github.com/owner/repo/issues/49",
+    labels: [{ name: "enhancement" }],
+  },
+  {
+    number: 48,
+    title: "Question about API usage",
+    state: "closed" as const,
+    user: { login: "user3" },
+    html_url: "https://github.com/owner/repo/issues/48",
+    labels: [{ name: "question" }],
+  },
+];
+
+export const mockIssueListWithPullRequestsResponse = [
+  {
+    number: 52,
+    title: "Real issue here",
+    state: "open" as const,
+    user: { login: "user1" },
+    html_url: "https://github.com/owner/repo/issues/52",
+    labels: [{ name: "bug" }],
+  },
+  {
+    number: 51,
+    title: "This is actually a PR",
+    state: "open" as const,
+    user: { login: "developer1" },
+    html_url: "https://github.com/owner/repo/pull/51",
+    pull_request: { url: "https://api.github.com/repos/owner/repo/pulls/51" },
+  },
+];

--- a/tests/integration/gh-issues-integration.test.ts
+++ b/tests/integration/gh-issues-integration.test.ts
@@ -1,0 +1,197 @@
+import { describe, expect, test } from "bun:test";
+import { handleGhIssues } from "../../src/handlers/gh-issues-handler";
+import { createMockBotHandler } from "../fixtures/mock-bot-handler";
+
+/**
+ * Integration test for gh_issues handler
+ * This test makes REAL API calls to GitHub to verify actual behavior
+ */
+describe("gh_issues handler - Integration", () => {
+  test("should fetch real GitHub issues from facebook/react", async () => {
+    const mockHandler = createMockBotHandler();
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["facebook/react", "5"],
+    });
+
+    // Should have sent exactly one message
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [channelId, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Verify it's sending to the right channel
+    expect(channelId).toBe("test-channel");
+
+    // If we got an error message, log it for debugging
+    if (message.startsWith("❌ Error:")) {
+      console.error("GitHub API Error:", message);
+      console.error("GITHUB_TOKEN set:", !!process.env.GITHUB_TOKEN);
+      console.error(
+        "GITHUB_TOKEN length:",
+        process.env.GITHUB_TOKEN?.length || 0
+      );
+    }
+
+    // Should contain the header
+    expect(message).toContain("**Recent Issues - facebook/react**");
+    expect(message).toContain("Showing");
+    expect(message).toContain("most recent issues:");
+
+    // Should have hyperlinked issue numbers [#xxx](url)
+    expect(message).toMatch(
+      /\[#\d+\]\(https:\/\/github\.com\/facebook\/react\/issues\/\d+\)/
+    );
+
+    // Should have status indicators
+    expect(message).toMatch(/🟢 Open|✅ Closed/);
+
+    // Should have "by" author
+    expect(message).toContain("by");
+
+    // Log the actual message for inspection
+    console.log("\n📋 Actual issues message sent:");
+    console.log(message);
+  }, 15000); // 15 second timeout for API call
+
+  test("should handle custom count parameter", async () => {
+    const mockHandler = createMockBotHandler();
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["facebook/react", "3"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Should show correct count
+    expect(message).toContain("Showing");
+    expect(message).toContain("most recent issues:");
+
+    console.log("\n📋 Issues with count=3:");
+    console.log(message);
+  }, 15000);
+
+  test("should filter out pull requests from results", async () => {
+    const mockHandler = createMockBotHandler();
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["facebook/react", "10"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // All URLs should be /issues/ not /pull/
+    const pullMatches = message.match(/\/pull\/\d+/g);
+    expect(pullMatches).toBeNull();
+
+    // Should have /issues/ URLs
+    const issueMatches = message.match(/\/issues\/\d+/g);
+    if (!message.includes("No issues found")) {
+      expect(issueMatches).not.toBeNull();
+    }
+
+    console.log("\n📋 Filtered issues (no PRs):");
+    console.log(message);
+  }, 15000);
+
+  test("should handle non-existent repository gracefully", async () => {
+    const mockHandler = createMockBotHandler();
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["this-repo/does-not-exist-12345"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Should get a proper error message
+    expect(message).toContain("❌ Error:");
+
+    console.log("\n❌ Error message for non-existent repo:");
+    console.log(message);
+  }, 15000);
+
+  test("should handle repository with no issues gracefully", async () => {
+    const mockHandler = createMockBotHandler();
+
+    // Using a small repo that might not have issues
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["github/gitignore"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Should either show issues or say no issues found
+    if (message.includes("No issues found")) {
+      expect(message).toMatch(/No issues found for \*\*github\/gitignore\*\*/);
+    } else {
+      // Or it might have some issues
+      expect(message).toContain("**Recent Issues - github/gitignore**");
+    }
+
+    console.log("\n📋 Message for repo with few/no issues:");
+    console.log(message);
+  }, 15000);
+
+  test("should show correct issue statuses (open/closed)", async () => {
+    const mockHandler = createMockBotHandler();
+
+    // facebook/react is a large repo with both open and closed issues
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["facebook/react", "20"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Should have at least one status indicator
+    const hasOpen = message.includes("🟢 Open");
+    const hasClosed = message.includes("✅ Closed");
+
+    expect(hasOpen || hasClosed).toBe(true);
+
+    console.log("\n📊 Issue statuses present:");
+    console.log(`Open: ${hasOpen}, Closed: ${hasClosed}`);
+  }, 15000);
+
+  test("should handle repos with mostly PRs (filter them out)", async () => {
+    const mockHandler = createMockBotHandler();
+
+    // Some repos might have more PRs than issues
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["facebook/react", "5"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Should either show issues or mention that only PRs were found
+    if (message.includes("(only PRs available)")) {
+      expect(message).toContain(
+        "No issues found for **facebook/react** (only PRs available)"
+      );
+    } else if (!message.startsWith("❌ Error:")) {
+      // If no error, should have valid issue links
+      expect(message).toContain("/issues/");
+      expect(message).not.toContain("/pull/");
+    }
+
+    console.log("\n📋 Issues filtered from PRs:");
+    console.log(message);
+  }, 15000);
+});

--- a/tests/integration/gh-prs-integration.test.ts
+++ b/tests/integration/gh-prs-integration.test.ts
@@ -1,0 +1,146 @@
+import { describe, expect, test } from "bun:test";
+import { handleGhPrs } from "../../src/handlers/gh-prs-handler";
+import { createMockBotHandler } from "../fixtures/mock-bot-handler";
+
+/**
+ * Integration test for gh_prs handler
+ * This test makes REAL API calls to GitHub to verify actual behavior
+ */
+describe("gh_prs handler - Integration", () => {
+  test("should fetch real GitHub PRs from facebook/react", async () => {
+    const mockHandler = createMockBotHandler();
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["facebook/react", "5"],
+    });
+
+    // Should have sent exactly one message
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [channelId, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Verify it's sending to the right channel
+    expect(channelId).toBe("test-channel");
+
+    // If we got an error message, log it for debugging
+    if (message.startsWith("❌ Error:")) {
+      console.error("GitHub API Error:", message);
+      console.error("GITHUB_TOKEN set:", !!process.env.GITHUB_TOKEN);
+      console.error(
+        "GITHUB_TOKEN length:",
+        process.env.GITHUB_TOKEN?.length || 0
+      );
+    }
+
+    // Should contain the header
+    expect(message).toContain("**Recent Pull Requests - facebook/react**");
+    expect(message).toContain("Showing");
+    expect(message).toContain("most recent PRs:");
+
+    // Should have hyperlinked PR numbers [#xxx](url)
+    expect(message).toMatch(
+      /\[#\d+\]\(https:\/\/github\.com\/facebook\/react\/pull\/\d+\)/
+    );
+
+    // Should have status indicators
+    expect(message).toMatch(/🟢 Open|✅ Merged|❌ Closed/);
+
+    // Should have "by" author
+    expect(message).toContain("by");
+
+    // Log the actual message for inspection
+    console.log("\n📋 Actual PRs message sent:");
+    console.log(message);
+  }, 15000); // 15 second timeout for API call
+
+  test("should handle custom count parameter", async () => {
+    const mockHandler = createMockBotHandler();
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["facebook/react", "3"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Should show correct count (approximately, as it might show "Showing N most recent PRs")
+    expect(message).toContain("Showing 3 most recent PRs:");
+
+    console.log("\n📋 PRs with count=3:");
+    console.log(message);
+  }, 15000);
+
+  test("should handle non-existent repository gracefully", async () => {
+    const mockHandler = createMockBotHandler();
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["this-repo/does-not-exist-12345"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Should get a proper error message
+    expect(message).toContain("❌ Error:");
+
+    console.log("\n❌ Error message for non-existent repo:");
+    console.log(message);
+  }, 15000);
+
+  test("should handle repository with no PRs gracefully", async () => {
+    const mockHandler = createMockBotHandler();
+
+    // Using a very small repo that likely has no PRs
+    // Note: This might fail if the repo gains PRs in the future
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["github/gitignore"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Should either show PRs or say no PRs found
+    if (message.includes("No pull requests found")) {
+      expect(message).toContain(
+        "No pull requests found for **github/gitignore**"
+      );
+    } else {
+      // Or it might have some PRs
+      expect(message).toContain("**Recent Pull Requests - github/gitignore**");
+    }
+
+    console.log("\n📋 Message for repo with few/no PRs:");
+    console.log(message);
+  }, 15000);
+
+  test("should show correct PR statuses (open/merged/closed)", async () => {
+    const mockHandler = createMockBotHandler();
+
+    // facebook/react is a large repo with all types of PRs
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["facebook/react", "20"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const [, message] = mockHandler.sendMessage.mock.calls[0];
+
+    // Should have at least one status indicator
+    const hasOpen = message.includes("🟢 Open");
+    const hasMerged = message.includes("✅ Merged");
+    const hasClosed = message.includes("❌ Closed");
+
+    expect(hasOpen || hasMerged || hasClosed).toBe(true);
+
+    console.log("\n📊 PR statuses present:");
+    console.log(`Open: ${hasOpen}, Merged: ${hasMerged}, Closed: ${hasClosed}`);
+  }, 15000);
+});

--- a/tests/unit/handlers/gh-issues-handler.test.ts
+++ b/tests/unit/handlers/gh-issues-handler.test.ts
@@ -1,0 +1,282 @@
+import { describe, expect, test, beforeEach, spyOn } from "bun:test";
+import { handleGhIssues } from "../../../src/handlers/gh-issues-handler";
+import { createMockBotHandler } from "../../fixtures/mock-bot-handler";
+import {
+  mockIssueListResponse,
+  mockIssueListWithPullRequestsResponse,
+} from "../../fixtures/github-payloads";
+import * as githubClient from "../../../src/api/github-client";
+
+describe("gh_issues handler", () => {
+  let mockHandler: ReturnType<typeof createMockBotHandler>;
+
+  beforeEach(() => {
+    mockHandler = createMockBotHandler();
+    mockHandler.sendMessage.mockClear();
+  });
+
+  test("should send error for missing arguments", async () => {
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: [],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Usage: `/gh_issues owner/repo [count]`\n\nExample: `/gh_issues facebook/react 5`"
+    );
+  });
+
+  test("should use default count of 10 when not specified", async () => {
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockResolvedValue(
+      mockIssueListResponse
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 10);
+
+    listIssuesSpy.mockRestore();
+  });
+
+  test("should use custom count when specified", async () => {
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockResolvedValue(
+      mockIssueListResponse
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo", "5"],
+    });
+
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 5);
+
+    listIssuesSpy.mockRestore();
+  });
+
+  test("should send error for invalid count (NaN)", async () => {
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo", "invalid"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Count must be a number between 1 and 50"
+    );
+  });
+
+  test("should send error for count < 1", async () => {
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo", "0"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Count must be a number between 1 and 50"
+    );
+  });
+
+  test("should send error for count > 50", async () => {
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo", "100"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Count must be a number between 1 and 50"
+    );
+  });
+
+  test("should fetch and display list of issues with hyperlinks", async () => {
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockResolvedValue(
+      mockIssueListResponse
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 10);
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const sentMessage = mockHandler.sendMessage.mock.calls[0][1];
+    expect(sentMessage).toContain("**Recent Issues - owner/repo**");
+    expect(sentMessage).toContain("Showing 3 most recent issues:");
+
+    // Check for hyperlinked issue numbers
+    expect(sentMessage).toContain(
+      "[#50](https://github.com/owner/repo/issues/50)"
+    );
+    expect(sentMessage).toContain(
+      "[#49](https://github.com/owner/repo/issues/49)"
+    );
+    expect(sentMessage).toContain(
+      "[#48](https://github.com/owner/repo/issues/48)"
+    );
+
+    // Check for issue titles and authors
+    expect(sentMessage).toContain("**Bug: App crashes on startup**");
+    expect(sentMessage).toContain("by user1");
+    expect(sentMessage).toContain("**Feature request: Add dark mode**");
+    expect(sentMessage).toContain("by user2");
+    expect(sentMessage).toContain("**Question about API usage**");
+    expect(sentMessage).toContain("by user3");
+
+    // Check for status indicators
+    expect(sentMessage).toContain("🟢 Open");
+    expect(sentMessage).toContain("✅ Closed");
+
+    listIssuesSpy.mockRestore();
+  });
+
+  test("should filter out pull requests from issues list", async () => {
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockResolvedValue(
+      mockIssueListWithPullRequestsResponse
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    const sentMessage = mockHandler.sendMessage.mock.calls[0][1];
+
+    // Should show the real issue
+    expect(sentMessage).toContain(
+      "[#52](https://github.com/owner/repo/issues/52)"
+    );
+    expect(sentMessage).toContain("**Real issue here**");
+
+    // Should NOT show the PR
+    expect(sentMessage).not.toContain("#51");
+    expect(sentMessage).not.toContain("This is actually a PR");
+
+    // Should show correct count
+    expect(sentMessage).toContain("Showing 1 most recent issues:");
+
+    listIssuesSpy.mockRestore();
+  });
+
+  test("should handle when all items are PRs (no actual issues)", async () => {
+    const onlyPRs = [
+      {
+        number: 51,
+        title: "This is actually a PR",
+        state: "open" as const,
+        user: { login: "developer1" },
+        html_url: "https://github.com/owner/repo/pull/51",
+        pull_request: {
+          url: "https://api.github.com/repos/owner/repo/pulls/51",
+        },
+        labels: [],
+        comments: 0,
+      },
+    ];
+
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockResolvedValue(
+      onlyPRs
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "No issues found for **owner/repo** (only PRs available)"
+    );
+
+    listIssuesSpy.mockRestore();
+  });
+
+  test("should handle empty issues list", async () => {
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockResolvedValue(
+      []
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "No issues found for **owner/repo**"
+    );
+
+    listIssuesSpy.mockRestore();
+  });
+
+  test("should handle GitHub API errors", async () => {
+    const error = new Error("GitHub API error: 404 Not Found");
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockRejectedValue(
+      error
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Error: GitHub API error: 404 Not Found"
+    );
+
+    listIssuesSpy.mockRestore();
+  });
+
+  test("should strip markdown formatting from repo name", async () => {
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockResolvedValue(
+      mockIssueListResponse
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["**owner/repo**", "5"],
+    });
+
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 5);
+
+    listIssuesSpy.mockRestore();
+  });
+
+  test("should strip markdown code formatting from arguments", async () => {
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockResolvedValue(
+      mockIssueListResponse
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["`owner/repo`", "`5`"],
+    });
+
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 5);
+
+    listIssuesSpy.mockRestore();
+  });
+
+  test("should preserve underscores in repo names", async () => {
+    const listIssuesSpy = spyOn(githubClient, "listIssues").mockResolvedValue(
+      mockIssueListResponse
+    );
+
+    await handleGhIssues(mockHandler, {
+      channelId: "test-channel",
+      args: ["**my__repo__name**"],
+    });
+
+    expect(listIssuesSpy).toHaveBeenCalledWith("my__repo__name", 10);
+
+    listIssuesSpy.mockRestore();
+  });
+});

--- a/tests/unit/handlers/gh-prs-handler.test.ts
+++ b/tests/unit/handlers/gh-prs-handler.test.ts
@@ -1,0 +1,227 @@
+import { describe, expect, test, beforeEach, spyOn } from "bun:test";
+import { handleGhPrs } from "../../../src/handlers/gh-prs-handler";
+import { createMockBotHandler } from "../../fixtures/mock-bot-handler";
+import { mockPullRequestListResponse } from "../../fixtures/github-payloads";
+import * as githubClient from "../../../src/api/github-client";
+
+describe("gh_prs handler", () => {
+  let mockHandler: ReturnType<typeof createMockBotHandler>;
+
+  beforeEach(() => {
+    mockHandler = createMockBotHandler();
+    mockHandler.sendMessage.mockClear();
+  });
+
+  test("should send error for missing arguments", async () => {
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: [],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Usage: `/gh_prs owner/repo [count]`\n\nExample: `/gh_prs facebook/react 5`"
+    );
+  });
+
+  test("should use default count of 10 when not specified", async () => {
+    const listPRsSpy = spyOn(
+      githubClient,
+      "listPullRequests"
+    ).mockResolvedValue(mockPullRequestListResponse);
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 10);
+
+    listPRsSpy.mockRestore();
+  });
+
+  test("should use custom count when specified", async () => {
+    const listPRsSpy = spyOn(
+      githubClient,
+      "listPullRequests"
+    ).mockResolvedValue(mockPullRequestListResponse);
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo", "5"],
+    });
+
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 5);
+
+    listPRsSpy.mockRestore();
+  });
+
+  test("should send error for invalid count (NaN)", async () => {
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo", "invalid"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Count must be a number between 1 and 50"
+    );
+  });
+
+  test("should send error for count < 1", async () => {
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo", "0"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Count must be a number between 1 and 50"
+    );
+  });
+
+  test("should send error for count > 50", async () => {
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo", "100"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Count must be a number between 1 and 50"
+    );
+  });
+
+  test("should fetch and display list of PRs with hyperlinks", async () => {
+    const listPRsSpy = spyOn(
+      githubClient,
+      "listPullRequests"
+    ).mockResolvedValue(mockPullRequestListResponse);
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 10);
+    expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
+
+    const sentMessage = mockHandler.sendMessage.mock.calls[0][1];
+    expect(sentMessage).toContain("**Recent Pull Requests - owner/repo**");
+    expect(sentMessage).toContain("Showing 3 most recent PRs:");
+
+    // Check for hyperlinked PR numbers
+    expect(sentMessage).toContain(
+      "[#100](https://github.com/owner/repo/pull/100)"
+    );
+    expect(sentMessage).toContain(
+      "[#99](https://github.com/owner/repo/pull/99)"
+    );
+    expect(sentMessage).toContain(
+      "[#98](https://github.com/owner/repo/pull/98)"
+    );
+
+    // Check for PR titles and authors
+    expect(sentMessage).toContain("**Add new feature X**");
+    expect(sentMessage).toContain("by developer1");
+    expect(sentMessage).toContain("**Fix bug in component Y**");
+    expect(sentMessage).toContain("by developer2");
+    expect(sentMessage).toContain("**Update documentation**");
+    expect(sentMessage).toContain("by developer3");
+
+    // Check for status indicators
+    expect(sentMessage).toContain("🟢 Open");
+    expect(sentMessage).toContain("✅ Merged");
+    expect(sentMessage).toContain("❌ Closed");
+
+    listPRsSpy.mockRestore();
+  });
+
+  test("should handle empty PR list", async () => {
+    const listPRsSpy = spyOn(
+      githubClient,
+      "listPullRequests"
+    ).mockResolvedValue([]);
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "No pull requests found for **owner/repo**"
+    );
+
+    listPRsSpy.mockRestore();
+  });
+
+  test("should handle GitHub API errors", async () => {
+    const error = new Error("GitHub API error: 404 Not Found");
+    const listPRsSpy = spyOn(
+      githubClient,
+      "listPullRequests"
+    ).mockRejectedValue(error);
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["owner/repo"],
+    });
+
+    expect(mockHandler.sendMessage).toHaveBeenCalledWith(
+      "test-channel",
+      "❌ Error: GitHub API error: 404 Not Found"
+    );
+
+    listPRsSpy.mockRestore();
+  });
+
+  test("should strip markdown formatting from repo name", async () => {
+    const listPRsSpy = spyOn(
+      githubClient,
+      "listPullRequests"
+    ).mockResolvedValue(mockPullRequestListResponse);
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["**owner/repo**", "5"],
+    });
+
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 5);
+
+    listPRsSpy.mockRestore();
+  });
+
+  test("should strip markdown code formatting from arguments", async () => {
+    const listPRsSpy = spyOn(
+      githubClient,
+      "listPullRequests"
+    ).mockResolvedValue(mockPullRequestListResponse);
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["`owner/repo`", "`5`"],
+    });
+
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 5);
+
+    listPRsSpy.mockRestore();
+  });
+
+  test("should preserve underscores in repo names", async () => {
+    const listPRsSpy = spyOn(
+      githubClient,
+      "listPullRequests"
+    ).mockResolvedValue(mockPullRequestListResponse);
+
+    await handleGhPrs(mockHandler, {
+      channelId: "test-channel",
+      args: ["**my__repo__name**"],
+    });
+
+    expect(listPRsSpy).toHaveBeenCalledWith("my__repo__name", 10);
+
+    listPRsSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
Add new /gh_prs and /gh_issues commands to list recent pull requests and issues from a GitHub repository. Both commands support:

- Listing recent PRs/issues with configurable count (default: 10, max: 50)
- Embedded hyperlinks in PR/issue numbers for easy navigation
- Status indicators (open/merged/closed for PRs, open/closed for issues)
- Automatic filtering of PRs from issues list

Changes:
- Add listPullRequests and listIssues API functions
- Add gh-prs-handler and gh-issues-handler
- Add pull_request field to GitHubIssue type for filtering
- Update help command with new commands
- Add comprehensive unit and integration tests