### PR TITLE
feat: add filtering to gh_prs and gh_issues commands

### DIFF
--- a/src/handlers/gh-prs-handler.ts
+++ b/src/handlers/gh-prs-handler.ts
@@ -1,6 +1,6 @@
 import type { BotHandler } from "@towns-protocol/bot";
 import { listPullRequests } from "../api/github-client";
-import { stripMarkdown } from "../utils/stripper";
+import { parseCommandArgs, validatePrFilters } from "../utils/arg-parser";
 
 interface GhPrsEvent {
   channelId: string;
@@ -16,14 +16,20 @@ export async function handleGhPrs(
   if (args.length < 1) {
     await handler.sendMessage(
       channelId,
-      "❌ Usage: `/gh_prs owner/repo [count]`\n\nExample: `/gh_prs facebook/react 5`"
+      "❌ Usage: `/gh_prs owner/repo [count] [--state=open|closed|merged|all] [--author=username]`\n\nExample: `/gh_prs facebook/react 5 --state=open`"
     );
     return;
   }
 
-  // Strip markdown formatting from arguments
-  const repo = stripMarkdown(args[0]);
-  const count = args[1] ? parseInt(stripMarkdown(args[1])) : 10;
+  // Parse arguments with filters
+  const { repo, count, filters } = parseCommandArgs(args);
+
+  // Validate filters
+  const validationError = validatePrFilters(filters);
+  if (validationError) {
+    await handler.sendMessage(channelId, `❌ ${validationError}`);
+    return;
+  }
 
   if (isNaN(count) || count < 1 || count > 50) {
     await handler.sendMessage(
@@ -34,7 +40,7 @@ export async function handleGhPrs(
   }
 
   try {
-    const prs = await listPullRequests(repo, count);
+    const prs = await listPullRequests(repo, count, filters);
 
     if (prs.length === 0) {
       await handler.sendMessage(

--- a/src/index.ts
+++ b/src/index.ts
@@ -48,9 +48,9 @@ bot.onSlashCommand("help", async (handler, { channelId }) => {
       "**Query Commands:**\n" +
       "• `/gh_pr owner/repo #123 [--full]` - Show pull request details\n" +
       "• `/gh_issue owner/repo #123 [--full]` - Show issue details\n" +
-      "• `/gh_prs owner/repo [count]` - List recent pull requests (default: 10, max: 50)\n" +
-      "• `/gh_issues owner/repo [count]` - List recent issues (default: 10, max: 50)\n" +
-      "• Add `--full` flag to show complete description\n\n" +
+      "• `/gh_prs owner/repo [count] [--state=...] [--author=...]` - List PRs\n" +
+      "• `/gh_issues owner/repo [count] [--state=...] [--creator=...]` - List issues\n" +
+      "• Filters: --state=open|closed|merged|all, --author/--creator=username\n\n" +
       "**Other Commands:**\n" +
       "• `/help` - Show this help message"
   );

--- a/src/utils/arg-parser.ts
+++ b/src/utils/arg-parser.ts
@@ -1,0 +1,75 @@
+import { stripMarkdown } from "./stripper";
+
+export interface FilterOptions {
+  state?: string;
+  author?: string;
+  creator?: string;
+}
+
+export interface ParsedCommandArgs {
+  repo: string;
+  count: number;
+  filters: FilterOptions;
+}
+
+export function parseCommandArgs(args: string[]): ParsedCommandArgs {
+  const filters: FilterOptions = {};
+  let repo = "";
+  let count = 10;
+
+  for (const arg of args) {
+    if (arg.startsWith("--")) {
+      // Parse flag: --key=value
+      const flagContent = arg.substring(2);
+      const equalIndex = flagContent.indexOf("=");
+
+      if (equalIndex === -1) {
+        continue; // Skip flags without values
+      }
+
+      const key = flagContent.substring(0, equalIndex);
+      const value = stripMarkdown(flagContent.substring(equalIndex + 1));
+
+      if (key === "state" || key === "author" || key === "creator") {
+        filters[key] = value;
+      }
+    } else if (!repo) {
+      repo = stripMarkdown(arg);
+    } else {
+      // Always parse count, even if it results in NaN for validation
+      count = parseInt(stripMarkdown(arg));
+    }
+  }
+
+  return { repo, count, filters };
+}
+
+export function validatePrFilters(filters: FilterOptions): string | null {
+  if (filters.state) {
+    const validStates = ["open", "closed", "merged", "all"];
+    if (!validStates.includes(filters.state)) {
+      return `Invalid state: '${filters.state}'. Use: open, closed, merged, or all`;
+    }
+  }
+
+  if (filters.creator) {
+    return "Invalid filter: 'creator' is only for issues. Use --author for PRs";
+  }
+
+  return null;
+}
+
+export function validateIssueFilters(filters: FilterOptions): string | null {
+  if (filters.state) {
+    const validStates = ["open", "closed", "all"];
+    if (!validStates.includes(filters.state)) {
+      return `Invalid state: '${filters.state}'. Use: open, closed, or all`;
+    }
+  }
+
+  if (filters.author) {
+    return "Invalid filter: 'author' is only for PRs. Use --creator for issues";
+  }
+
+  return null;
+}

--- a/tests/unit/handlers/gh-issues-handler.test.ts
+++ b/tests/unit/handlers/gh-issues-handler.test.ts
@@ -24,7 +24,7 @@ describe("gh_issues handler", () => {
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Usage: `/gh_issues owner/repo [count]`\n\nExample: `/gh_issues facebook/react 5`"
+      "❌ Usage: `/gh_issues owner/repo [count] [--state=open|closed|all] [--creator=username]`\n\nExample: `/gh_issues facebook/react 5 --state=open`"
     );
   });
 
@@ -38,7 +38,7 @@ describe("gh_issues handler", () => {
       args: ["owner/repo"],
     });
 
-    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 10);
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 10, {});
 
     listIssuesSpy.mockRestore();
   });
@@ -53,7 +53,7 @@ describe("gh_issues handler", () => {
       args: ["owner/repo", "5"],
     });
 
-    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 5);
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 5, {});
 
     listIssuesSpy.mockRestore();
   });
@@ -104,7 +104,7 @@ describe("gh_issues handler", () => {
       args: ["owner/repo"],
     });
 
-    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 10);
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 10, {});
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
 
     const sentMessage = mockHandler.sendMessage.mock.calls[0][1];
@@ -235,7 +235,7 @@ describe("gh_issues handler", () => {
       args: ["**owner/repo**", "5"],
     });
 
-    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 5);
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 5, {});
 
     listIssuesSpy.mockRestore();
   });
@@ -250,7 +250,7 @@ describe("gh_issues handler", () => {
       args: ["`owner/repo`", "`5`"],
     });
 
-    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 5);
+    expect(listIssuesSpy).toHaveBeenCalledWith("owner/repo", 5, {});
 
     listIssuesSpy.mockRestore();
   });
@@ -265,7 +265,7 @@ describe("gh_issues handler", () => {
       args: ["**my__repo__name**"],
     });
 
-    expect(listIssuesSpy).toHaveBeenCalledWith("my__repo__name", 10);
+    expect(listIssuesSpy).toHaveBeenCalledWith("my__repo__name", 10, {});
 
     listIssuesSpy.mockRestore();
   });

--- a/tests/unit/handlers/gh-prs-handler.test.ts
+++ b/tests/unit/handlers/gh-prs-handler.test.ts
@@ -21,7 +21,7 @@ describe("gh_prs handler", () => {
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
     expect(mockHandler.sendMessage).toHaveBeenCalledWith(
       "test-channel",
-      "❌ Usage: `/gh_prs owner/repo [count]`\n\nExample: `/gh_prs facebook/react 5`"
+      "❌ Usage: `/gh_prs owner/repo [count] [--state=open|closed|merged|all] [--author=username]`\n\nExample: `/gh_prs facebook/react 5 --state=open`"
     );
   });
 
@@ -36,7 +36,7 @@ describe("gh_prs handler", () => {
       args: ["owner/repo"],
     });
 
-    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 10);
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 10, {});
 
     listPRsSpy.mockRestore();
   });
@@ -52,7 +52,7 @@ describe("gh_prs handler", () => {
       args: ["owner/repo", "5"],
     });
 
-    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 5);
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 5, {});
 
     listPRsSpy.mockRestore();
   });
@@ -104,7 +104,7 @@ describe("gh_prs handler", () => {
       args: ["owner/repo"],
     });
 
-    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 10);
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 10, {});
     expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
 
     const sentMessage = mockHandler.sendMessage.mock.calls[0][1];
@@ -188,7 +188,7 @@ describe("gh_prs handler", () => {
       args: ["**owner/repo**", "5"],
     });
 
-    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 5);
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 5, {});
 
     listPRsSpy.mockRestore();
   });
@@ -204,7 +204,7 @@ describe("gh_prs handler", () => {
       args: ["`owner/repo`", "`5`"],
     });
 
-    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 5);
+    expect(listPRsSpy).toHaveBeenCalledWith("owner/repo", 5, {});
 
     listPRsSpy.mockRestore();
   });
@@ -220,7 +220,7 @@ describe("gh_prs handler", () => {
       args: ["**my__repo__name**"],
     });
 
-    expect(listPRsSpy).toHaveBeenCalledWith("my__repo__name", 10);
+    expect(listPRsSpy).toHaveBeenCalledWith("my__repo__name", 10, {});
 
     listPRsSpy.mockRestore();
   });


### PR DESCRIPTION
Add state and author/creator filtering for PR and issue list commands:
- Created arg-parser.ts for flag-based argument parsing (--key=value)
- Added --state filter (open/closed/merged/all for PRs, open/closed/all for issues)
- Added --author filter for PRs and --creator filter for issues
- Implemented pagination to fetch multiple pages until count is met
- Strip markdown from filter values to handle bold formatting
- Updated help text and all tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)