### PR TITLE
feat: support watch and fork events

### DIFF
--- a/src/constants/event-types.ts
+++ b/src/constants/event-types.ts
@@ -17,4 +17,6 @@ export const ALLOWED_EVENT_TYPES = [
   "reviews",
   "branches",
   "review_comments",
+  "stars",
+  "forks",
 ] as const;

--- a/src/formatters/events-api.ts
+++ b/src/formatters/events-api.ts
@@ -268,6 +268,33 @@ export function formatEvent(
       );
     }
 
+    case "WatchEvent": {
+      if (payload.action !== "started") return "";
+
+      return (
+        `⭐ **Repository Starred**\n` +
+        `**${repo.name}**\n` +
+        `👤 ${actor.login}\n` +
+        `🔗 https://github.com/${repo.name}`
+      );
+    }
+
+    case "ForkEvent": {
+      const { forkee } = payload;
+      if (!forkee?.full_name) return "";
+
+      const targetUrl =
+        forkee.html_url ??
+        `https://github.com/${forkee.full_name.replace(/^\/+/, "")}`;
+
+      return (
+        `🍴 **Repository Forked**\n` +
+        `**${repo.name}** → **${forkee.full_name}**\n` +
+        `👤 ${actor.login}\n` +
+        `🔗 ${targetUrl}`
+      );
+    }
+
     // Ignore other event types for now
     default:
       return "";

--- a/src/handlers/github-subscription-handler.ts
+++ b/src/handlers/github-subscription-handler.ts
@@ -88,7 +88,7 @@ export async function handleGithubSubscription(
     await handler.sendMessage(
       channelId,
       "**Usage:**\n" +
-        "• `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,all]` - Subscribe to GitHub events\n" +
+        "• `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks,all]` - Subscribe to GitHub events\n" +
         "• `/github unsubscribe owner/repo` - Unsubscribe from a repository\n" +
         "• `/github status` - Show current subscriptions"
     );
@@ -100,7 +100,7 @@ export async function handleGithubSubscription(
       if (!repoArg) {
         await handler.sendMessage(
           channelId,
-          "❌ Usage: `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,all]`"
+          "❌ Usage: `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks,all]`"
         );
         return;
       }

--- a/src/services/polling-service.ts
+++ b/src/services/polling-service.ts
@@ -21,6 +21,8 @@ const EVENT_TYPE_MAP: Record<string, string> = {
   reviews: "PullRequestReviewEvent",
   branches: "CreateEvent,DeleteEvent",
   review_comments: "PullRequestReviewCommentEvent",
+  stars: "WatchEvent",
+  forks: "ForkEvent",
 };
 
 /**

--- a/tests/unit/formatters/events-api.test.ts
+++ b/tests/unit/formatters/events-api.test.ts
@@ -11,6 +11,8 @@ import type {
   CreateEvent,
   DeleteEvent,
   PullRequestReviewCommentEvent,
+  WatchEvent,
+  ForkEvent,
 } from "../../../src/types/events-api";
 import type { GitHubPullRequest } from "../../../src/api/github-client";
 
@@ -656,6 +658,69 @@ describe("formatEvent", () => {
         payload: {
           action: "edited",
         },
+      };
+
+      const result = formatEvent(event, new Map());
+      expect(result).toBe("");
+    });
+  });
+
+  describe("WatchEvent", () => {
+    test("formats star notification", () => {
+      const event: WatchEvent = {
+        ...baseEvent,
+        type: "WatchEvent",
+        payload: {
+          action: "started",
+        },
+      };
+
+      const result = formatEvent(event, new Map());
+      expect(result).toContain("⭐");
+      expect(result).toContain("Repository Starred");
+      expect(result).toContain("owner/repo");
+      expect(result).toContain("testuser");
+    });
+
+    test("returns empty string for other actions", () => {
+      const event: WatchEvent = {
+        ...baseEvent,
+        type: "WatchEvent",
+        payload: {
+          action: "stopped",
+        },
+      };
+
+      const result = formatEvent(event, new Map());
+      expect(result).toBe("");
+    });
+  });
+
+  describe("ForkEvent", () => {
+    test("formats fork notification", () => {
+      const event: ForkEvent = {
+        ...baseEvent,
+        type: "ForkEvent",
+        payload: {
+          forkee: {
+            full_name: "testuser/new-repo",
+            html_url: "https://github.com/testuser/new-repo",
+          },
+        },
+      };
+
+      const result = formatEvent(event, new Map());
+      expect(result).toContain("🍴");
+      expect(result).toContain("Repository Forked");
+      expect(result).toContain("testuser/new-repo");
+      expect(result).toContain("https://github.com/testuser/new-repo");
+    });
+
+    test("returns empty string when forkee missing", () => {
+      const event: ForkEvent = {
+        ...baseEvent,
+        type: "ForkEvent",
+        payload: {},
       };
 
       const result = formatEvent(event, new Map());

--- a/tests/unit/handlers/github-subscription-handler.test.ts
+++ b/tests/unit/handlers/github-subscription-handler.test.ts
@@ -23,7 +23,7 @@ describe("github subscription handler", () => {
       expect(mockHandler.sendMessage).toHaveBeenCalledWith(
         "test-channel",
         "**Usage:**\n" +
-          "• `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,all]` - Subscribe to GitHub events\n" +
+        "• `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks,all]` - Subscribe to GitHub events\n" +
           "• `/github unsubscribe owner/repo` - Unsubscribe from a repository\n" +
           "• `/github status` - Show current subscriptions"
       );
@@ -126,7 +126,7 @@ describe("github subscription handler", () => {
       expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
       expect(mockHandler.sendMessage).toHaveBeenCalledWith(
         "test-channel",
-        "❌ Usage: `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,all]`"
+        "❌ Usage: `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks,all]`"
       );
     });
 
@@ -263,7 +263,7 @@ describe("github subscription handler", () => {
       expect(subscribeSpy).toHaveBeenCalledWith(
         "test-channel",
         "owner/repo",
-        "pr,issues,commits,releases,ci,comments,reviews,branches,review_comments"
+        "pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks"
       );
 
       validateRepoSpy.mockRestore();

--- a/tests/unit/types/events-api.test.ts
+++ b/tests/unit/types/events-api.test.ts
@@ -389,6 +389,65 @@ describe("validateGitHubEvent", () => {
     });
   });
 
+  describe("WatchEvent", () => {
+    test("validates started action", () => {
+      const event = {
+        ...baseEvent,
+        type: "WatchEvent",
+        payload: {
+          action: "started",
+        },
+      };
+
+      const result = validateGitHubEvent(event);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("WatchEvent");
+    });
+
+    test("rejects other actions", () => {
+      const event = {
+        ...baseEvent,
+        type: "WatchEvent",
+        payload: {
+          action: "stopped",
+        },
+      };
+
+      const result = validateGitHubEvent(event);
+      expect(result).toBeNull();
+    });
+  });
+
+  describe("ForkEvent", () => {
+    test("validates fork event with forkee info", () => {
+      const event = {
+        ...baseEvent,
+        type: "ForkEvent",
+        payload: {
+          forkee: {
+            full_name: "testuser/repo-fork",
+            html_url: "https://github.com/testuser/repo-fork",
+          },
+        },
+      };
+
+      const result = validateGitHubEvent(event);
+      expect(result).not.toBeNull();
+      expect(result?.type).toBe("ForkEvent");
+    });
+
+    test("allows missing forkee data", () => {
+      const event = {
+        ...baseEvent,
+        type: "ForkEvent",
+        payload: {},
+      };
+
+      const result = validateGitHubEvent(event);
+      expect(result).not.toBeNull();
+    });
+  });
+
   describe("invalid events", () => {
     test("rejects event with missing type", () => {
       const event = {


### PR DESCRIPTION
- add WatchEvent/ForkEvent schemas, formatters, and tests
- expand subscription event type map and docs for stars/forks
- suppress validation logs for unsupported event types

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub subscriptions now support repository star and fork events, expanding the activity types you can monitor.

* **Tests**
  * Added comprehensive test coverage for new event types.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->