### PR TITLE
feat: add fork and watch webhook handlers

### DIFF
--- a/github-app-manifest.json
+++ b/github-app-manifest.json
@@ -25,6 +25,8 @@
     "pull_request_review",
     "pull_request_review_comment",
     "create",
-    "delete"
+    "delete",
+    "fork",
+    "watch"
   ]
 }

--- a/src/formatters/webhook-events.ts
+++ b/src/formatters/webhook-events.ts
@@ -11,6 +11,8 @@ import type {
   WorkflowRunPayload,
   IssueCommentPayload,
   PullRequestReviewPayload,
+  ForkPayload,
+  WatchPayload,
 } from "../types/webhooks";
 import { buildMessage } from "./shared";
 
@@ -179,6 +181,32 @@ export function formatPullRequestReview(
       `**${pull_request.title}**\n` +
       `👤 ${review.user?.login || "unknown"}\n` +
       `🔗 ${review.html_url}`
+    );
+  }
+
+  return "";
+}
+
+export function formatFork(payload: ForkPayload): string {
+  const { forkee, repository, sender } = payload;
+
+  return (
+    `🍴 **Repository Forked**\n` +
+    `**${repository.full_name}** → **${forkee.full_name}**\n` +
+    `👤 ${sender.login}\n` +
+    `🔗 ${forkee.html_url}`
+  );
+}
+
+export function formatWatch(payload: WatchPayload): string {
+  const { action, repository, sender } = payload;
+
+  if (action === "started") {
+    return (
+      `⭐ **Repository Starred**\n` +
+      `**${repository.full_name}**\n` +
+      `👤 ${sender.login}\n` +
+      `🔗 ${repository.html_url}`
     );
   }
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -112,6 +112,14 @@ if (githubApp.isEnabled()) {
     await eventProcessor.onBranchEvent(payload, "delete");
   });
 
+  githubApp.webhooks.on("fork", async ({ payload }) => {
+    await eventProcessor.onFork(payload);
+  });
+
+  githubApp.webhooks.on("watch", async ({ payload }) => {
+    await eventProcessor.onWatch(payload);
+  });
+
   console.log("✅ GitHub App webhooks registered");
 } else {
   console.log("⚠️  GitHub App not configured - running in polling-only mode");

--- a/src/types/webhooks.ts
+++ b/src/types/webhooks.ts
@@ -23,3 +23,5 @@ export type InstallationRepositoriesPayload =
   WebhookPayload<"installation_repositories">;
 export type CreatePayload = WebhookPayload<"create">;
 export type DeletePayload = WebhookPayload<"delete">;
+export type ForkPayload = WebhookPayload<"fork">;
+export type WatchPayload = WebhookPayload<"watch">;


### PR DESCRIPTION
Add real-time webhook support for repository forks and stars:

1. Types (src/types/webhooks.ts)
   - Add ForkPayload and WatchPayload types

2. Formatters (src/formatters/webhook-events.ts)
   - Add formatFork() - formats fork events with forkee info
   - Add formatWatch() - formats star/watch events

3. Event Processor (src/github-app/event-processor.ts)
   - Add onFork() handler - filters by "forks" event type
   - Add onWatch() handler - filters by "stars" event type
   - Both filter by webhook deliveryMode to prevent duplicates

4. Webhook Registration (src/index.ts)
   - Register fork webhook listener
   - Register watch webhook listener

5. GitHub App Manifest (github-app-manifest.json)
   - Add "fork" and "watch" to default_events

These events were already supported in polling mode (via EVENT_TYPE_MAP). Now they work in webhook mode for real-time notifications when GitHub App is installed on the repository.

Users can subscribe with: /github subscribe owner/repo --events forks,stars

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for GitHub fork webhook events with formatted notifications
  * Added support for GitHub watch (star) webhook events with formatted notifications when repositories are starred

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->