### PR TITLE
fix: sync migration journal and add database scripts

### DIFF
--- a/README.md
+++ b/README.md
@@ -117,19 +117,31 @@ Receive real-time notifications for:
    DATABASE_SSL=false
    ```
 
-4. **Run the bot locally**
+4. **Database migrations** (automatic on startup)
+
+   Migrations run automatically when the bot starts. The database schema is created on first run.
+
+   Manual migration commands (if needed):
+
+   ```bash
+   bun run db:generate   # Generate new migrations from schema changes
+   bun run db:migrate    # Run pending migrations
+   bun run db:push       # Push schema directly (dev only)
+   ```
+
+5. **Run the bot locally**
 
    ```bash
    bun run dev
    ```
 
-5. **Expose webhook with ngrok** (for testing)
+6. **Expose webhook with ngrok** (for testing)
 
    ```bash
    ngrok http 5123
    ```
 
-6. **Update webhook URL in Developer Portal**
+7. **Update webhook URL in Developer Portal**
    - Set to: `https://your-ngrok-url.ngrok-free.app/webhook`
 
 ## Environment Variables

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -8,7 +8,13 @@
       "when": 1763577600000,
       "tag": "0000_postgres_init",
       "breakpoints": true
+    },
+    {
+      "idx": 1,
+      "version": "5",
+      "when": 1763577601000,
+      "tag": "0001_add_constraints",
+      "breakpoints": true
     }
   ]
 }
-

--- a/package.json
+++ b/package.json
@@ -6,6 +6,9 @@
   "scripts": {
     "build": "tsc --noEmit",
     "clean": "rm -rf dist",
+    "db:generate": "drizzle-kit generate",
+    "db:migrate": "drizzle-kit migrate",
+    "db:push": "drizzle-kit push",
     "dev": "bun run --watch src/index.ts",
     "format": "prettier --write \"src/**/*.ts\" \"tests/**/*.ts\"",
     "format:check": "prettier --check \"src/**/*.ts\" \"tests/**/*.ts\"",


### PR DESCRIPTION
**Problem:** Tables weren't being created despite "Database ready" message. The migration journal was out of sync - only listed 0000_postgres_init but 0001_add_constraints.sql existed and wasn't registered.

**Root Cause:** drizzle/meta/_journal.json was missing the second migration entry, causing drizzle-orm to skip running it.

**Fix:**

1. Migration Journal (drizzle/meta/_journal.json)
   - Added missing entry for 0001_add_constraints migration
   - Both migrations now properly registered (idx: 0 and 1)

2. Package Scripts (package.json)
   - Added db:generate - Generate migrations from schema changes
   - Added db:migrate - Run pending migrations
   - Added db:push - Push schema directly (development only)

3. Documentation (README.md)
   - Added step 4 explaining automatic migrations
   - Documented manual migration commands
   - Renumbered subsequent setup steps

**Tables Created:**
- github_user_tokens (OAuth tokens)
- oauth_states (OAuth flow state)
- github_subscriptions (repo subscriptions)
- repo_polling_state (polling tracking)
- github_installations (GitHub App installs)
- installation_repositories (install repos)
- webhook_deliveries (webhook tracking)

Migrations now run correctly on startup.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated setup guide with a new database migrations section, including automatic migration details and manual migration commands.
  * Reorganized setup workflow steps for improved clarity and logical ordering.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->