### PR TITLE
docs: update package name and README for OAuth architecture

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
-  "name": "my-bot",
-  "version": "0.0.1",
+  "name": "towns-github-bot",
+  "version": "1.0.0",
   "type": "module",
   "main": "src/index.ts",
   "scripts": {


### PR DESCRIPTION
**Package:**
- Rename my-bot → towns-github-bot
- Bump version to 1.0.0

**README:**
- Replace PAT-based docs with OAuth + GitHub App architecture
- Add all 10 event types (pr, issues, commits, releases, ci, comments, reviews, branches, forks, stars)
- Document dual delivery modes (webhook vs polling)
- Update code structure to reflect actual architecture
- Remove "public repos only" limitation (OAuth enables private repos)
- Add GitHub App setup instructions
- Update environment variables (remove GITHUB_TOKEN, add GitHub App credentials)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * GitHub App integration and OAuth-based authentication support
  * Dual delivery model: real-time webhook notifications with 5-minute polling fallback
  * New slash commands for repository subscriptions, event filtering, and status checks
  * Expanded GitHub event support including branch/tag creation/deletion, fork, and watch events

* **Documentation**
  * Updated setup and configuration guides with GitHub App prerequisites
  * Added quick setup guide for GitHub App creation and integration
  * Reorganized documentation structure for improved clarity

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->