### PR TITLE
feat: add agent metadata endpoint

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -168,6 +168,11 @@ app.use(logger());
 // Towns webhook endpoint
 app.post("/webhook", jwtMiddleware, handler);
 
+// Agent metadata endpoint
+app.get("/.well-known/agent-metadata.json", async c => {
+  return c.json(await bot.getIdentityMetadata());
+});
+
 // OAuth callback endpoint
 app.get("/oauth/callback", c =>
   handleOAuthCallback(c, oauthService, subscriptionService, bot)


### PR DESCRIPTION
Add /.well-known/agent-metadata.json route for Towns Protocol agent discovery. Returns bot identity metadata via getIdentityMetadata().

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added an agent metadata endpoint that returns the bot's identity information in a standard format

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->