### PR TITLE
feat: add GitHub API fallback for installation check

### DIFF
--- a/src/github-app/installation-service.ts
+++ b/src/github-app/installation-service.ts
@@ -143,11 +143,18 @@ export class InstallationService {
       }
 
       // DB miss - check GitHub API as fallback (handles DB out-of-sync scenarios)
-      const [owner, repoName] = repo.split("/");
-      if (!owner || !repoName) {
+      // Validate and parse repo string (must be exactly "owner/repo" format)
+      const normalized = repo.trim();
+      const parts = normalized.split("/");
+
+      if (parts.length !== 2 || !parts[0] || !parts[1]) {
+        console.warn(
+          `[InstallationService] Invalid repo format: "${repo}" (expected "owner/repo")`
+        );
         return null;
       }
 
+      const [owner, repoName] = parts;
       return await this.checkRepoInstallationFromAPI(owner, repoName);
     } catch (error) {
       console.warn(


### PR DESCRIPTION
When local DB is out of sync (webhook delays, manual purges, restoration), isRepoInstalled() now falls back to checking GitHub's API directly.

Changes:
- Add checkRepoInstallationFromAPI() to query GET /repos/{owner}/{repo}/installation
- Update isRepoInstalled() to use API fallback when DB check returns null
- Auto-sync installation data to DB when found via API
- Upgrade any polling subscriptions to webhook delivery after sync

Handles edge cases:
- Webhook delivery failures/delays
- Manual DB purges (dev/testing)
- DB restoration from backups
- Initial deployment with pre-existing installations

Rate limit: Uses app authentication (15,000/hour limit). DB-first approach minimizes API calls - only hit API on cache miss, then sync for future lookups.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved repository installation detection with a robust fallback to verify installation status via the external API for edge cases.
  * Repo identifier validation prevents malformed queries and returns null for invalid formats.
  * When external verification succeeds, installation records and subscription info are synchronized automatically to prevent false negatives.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->