### PR TITLE
refactor: use ALLOWED_EVENT_TYPES constant instead of hardcoded lists

### DIFF
--- a/src/handlers/github-subscription-handler.ts
+++ b/src/handlers/github-subscription-handler.ts
@@ -22,10 +22,10 @@ export async function handleGithubSubscription(
   if (!action) {
     await handler.sendMessage(
       channelId,
-      "**Usage:**\n" +
-        "• `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks,all]` - Subscribe to GitHub events\n" +
-        "• `/github unsubscribe owner/repo` - Unsubscribe from a repository\n" +
-        "• `/github status` - Show current subscriptions"
+      "**Usage:**\n\n" +
+        `- \`/github subscribe owner/repo [--events all,${ALLOWED_EVENT_TYPES.join(",")}]\` - Subscribe to GitHub events\n\n` +
+        "- `/github unsubscribe owner/repo` - Unsubscribe from a repository\n\n" +
+        "- `/github status` - Show current subscriptions"
     );
     return;
   }
@@ -73,7 +73,7 @@ async function handleSubscribe(
   if (!repoArg) {
     await handler.sendMessage(
       channelId,
-      "❌ Usage: `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks,all]`"
+      `❌ Usage: \`/github subscribe owner/repo [--events all,${ALLOWED_EVENT_TYPES.join(",")}]\``
     );
     return;
   }

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,6 +4,7 @@ import { logger } from "hono/logger";
 import { makeTownsBot } from "@towns-protocol/bot";
 
 import commands from "./commands";
+import { ALLOWED_EVENT_TYPES } from "./constants";
 import { db, dbReady } from "./db";
 import { githubInstallations } from "./db/schema";
 import { GitHubApp } from "./github-app/app";
@@ -140,7 +141,7 @@ bot.onSlashCommand("help", async (handler, { channelId }) => {
       "• `/github subscribe owner/repo [--events=pr,issues,...]`\n" +
       "• `/github unsubscribe owner/repo`\n" +
       "• `/github status`\n\n" +
-      "**Events:** pr, issues, commits, releases, ci, comments, reviews, branches, forks, stars\n\n" +
+      `**Events:** ${ALLOWED_EVENT_TYPES.join(", ")}\n\n` +
       "**Queries** _(public repos)_\n" +
       "• `/gh_pr owner/repo #123 [--full]`\n" +
       "• `/gh_pr list owner/repo [count] [--state=...] [--author=...]`\n" +

--- a/tests/unit/handlers/github-subscription-handler.test.ts
+++ b/tests/unit/handlers/github-subscription-handler.test.ts
@@ -1,6 +1,10 @@
 import { beforeEach, describe, expect, spyOn, test } from "bun:test";
 
 import * as githubClient from "../../../src/api/github-client";
+import {
+  ALLOWED_EVENT_TYPES,
+  DEFAULT_EVENT_TYPES,
+} from "../../../src/constants";
 import { dbService } from "../../../src/db";
 import { handleGithubSubscription } from "../../../src/handlers/github-subscription-handler";
 import { createMockBotHandler } from "../../fixtures/mock-bot-handler";
@@ -24,7 +28,7 @@ describe("github subscription handler", () => {
       expect(mockHandler.sendMessage).toHaveBeenCalledWith(
         "test-channel",
         "**Usage:**\n" +
-          "• `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks,all]` - Subscribe to GitHub events\n" +
+          `• \`/github subscribe owner/repo [--events all,${ALLOWED_EVENT_TYPES.join(",")}]\` - Subscribe to GitHub events\n` +
           "• `/github unsubscribe owner/repo` - Unsubscribe from a repository\n" +
           "• `/github status` - Show current subscriptions"
       );
@@ -78,7 +82,7 @@ describe("github subscription handler", () => {
         dbService,
         "getChannelSubscriptions"
       ).mockResolvedValue([
-        { repo: "owner/repo", eventTypes: "pr,issues,commits,releases" },
+        { repo: "owner/repo", eventTypes: DEFAULT_EVENT_TYPES },
       ]);
       const unsubscribeSpy = spyOn(dbService, "unsubscribe").mockResolvedValue(
         true
@@ -103,7 +107,7 @@ describe("github subscription handler", () => {
         dbService,
         "getChannelSubscriptions"
       ).mockResolvedValue([
-        { repo: "owner/repo", eventTypes: "pr,issues,commits,releases" },
+        { repo: "owner/repo", eventTypes: DEFAULT_EVENT_TYPES },
       ]);
 
       await handleGithubSubscription(mockHandler, {
@@ -129,7 +133,7 @@ describe("github subscription handler", () => {
       expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
       expect(mockHandler.sendMessage).toHaveBeenCalledWith(
         "test-channel",
-        "❌ Usage: `/github subscribe owner/repo [--events pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks,all]`"
+        `❌ Usage: \`/github subscribe owner/repo [--events all,${ALLOWED_EVENT_TYPES.join(",")}]\``
       );
     });
 
@@ -204,7 +208,7 @@ describe("github subscription handler", () => {
       expect(subscribeSpy).toHaveBeenCalledWith(
         "test-channel",
         "facebook/react",
-        "pr,issues,commits,releases"
+        DEFAULT_EVENT_TYPES
       );
       expect(mockHandler.sendMessage).toHaveBeenCalledTimes(1);
 
@@ -212,7 +216,7 @@ describe("github subscription handler", () => {
       expect(message).toContain(
         "✅ **Subscribed to [facebook/react](https://github.com/facebook/react)**"
       );
-      expect(message).toContain("pr, issues, commits, releases");
+      expect(message).toContain(DEFAULT_EVENT_TYPES.replace(/,/g, ", "));
 
       validateRepoSpy.mockRestore();
       isSubscribedSpy.mockRestore();
@@ -268,7 +272,7 @@ describe("github subscription handler", () => {
       expect(subscribeSpy).toHaveBeenCalledWith(
         "test-channel",
         "owner/repo",
-        "pr,issues,commits,releases,ci,comments,reviews,branches,review_comments,stars,forks"
+        ALLOWED_EVENT_TYPES.join(",")
       );
 
       validateRepoSpy.mockRestore();
@@ -326,7 +330,7 @@ describe("github subscription handler", () => {
       expect(subscribeSpy).toHaveBeenCalledWith(
         "test-channel",
         "owner/repo",
-        "pr,issues,commits,releases"
+        DEFAULT_EVENT_TYPES
       );
 
       validateRepoSpy.mockRestore();
@@ -419,7 +423,7 @@ describe("github subscription handler", () => {
         dbService,
         "getChannelSubscriptions"
       ).mockResolvedValue([
-        { repo: "owner/other", eventTypes: "pr,issues,commits,releases" },
+        { repo: "owner/other", eventTypes: DEFAULT_EVENT_TYPES },
       ]);
 
       await handleGithubSubscription(mockHandler, {
@@ -441,7 +445,7 @@ describe("github subscription handler", () => {
         dbService,
         "getChannelSubscriptions"
       ).mockResolvedValue([
-        { repo: "owner/repo", eventTypes: "pr,issues,commits,releases" },
+        { repo: "owner/repo", eventTypes: DEFAULT_EVENT_TYPES },
       ]);
       const unsubscribeSpy = spyOn(dbService, "unsubscribe").mockResolvedValue(
         true
@@ -466,7 +470,7 @@ describe("github subscription handler", () => {
         dbService,
         "getChannelSubscriptions"
       ).mockResolvedValue([
-        { repo: "owner/repo", eventTypes: "pr,issues,commits,releases" },
+        { repo: "owner/repo", eventTypes: DEFAULT_EVENT_TYPES },
       ]);
       const unsubscribeSpy = spyOn(dbService, "unsubscribe").mockResolvedValue(
         true
@@ -512,7 +516,7 @@ describe("github subscription handler", () => {
         dbService,
         "getChannelSubscriptions"
       ).mockResolvedValue([
-        { repo: "facebook/react", eventTypes: "pr,issues,commits,releases" },
+        { repo: "facebook/react", eventTypes: DEFAULT_EVENT_TYPES },
       ]);
 
       await handleGithubSubscription(mockHandler, {
@@ -532,7 +536,7 @@ describe("github subscription handler", () => {
         dbService,
         "getChannelSubscriptions"
       ).mockResolvedValue([
-        { repo: "facebook/react", eventTypes: "pr,issues,commits,releases" },
+        { repo: "facebook/react", eventTypes: DEFAULT_EVENT_TYPES },
         { repo: "microsoft/vscode", eventTypes: "pr,ci" },
         { repo: "vercel/next.js", eventTypes: "all" },
       ]);
@@ -545,7 +549,7 @@ describe("github subscription handler", () => {
       const message = mockHandler.sendMessage.mock.calls[0][1];
       expect(message).toContain("📬 **Subscribed Repositories (3):**");
       expect(message).toContain(
-        "• facebook/react (pr, issues, commits, releases)"
+        `• facebook/react (${DEFAULT_EVENT_TYPES.replace(/,/g, ", ")})`
       );
       expect(message).toContain("• microsoft/vscode (pr, ci)");
       expect(message).toContain("• vercel/next.js (all)");


### PR DESCRIPTION
Replace all hardcoded event type strings with ALLOWED_EVENT_TYPES constant to ensure help text and tests stay in sync when event types change.

Changes:
- Replace hardcoded event lists in help text with dynamic ALLOWED_EVENT_TYPES.join(",")
- Place "all" keyword before event types in usage messages
- Replace hardcoded event lists in tests with constant references
- Add ALLOWED_EVENT_TYPES import where needed

This ensures that whenever ALLOWED_EVENT_TYPES is updated, all references automatically reflect the new event types without manual updates.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Centralized event type definitions in GitHub subscription workflows, improving consistency across help messages, usage prompts, and subscription management.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->