### PR TITLE
fix(db): run migrations on app start only, not on module import

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -60,13 +60,20 @@ const migrationsFolder = process.env.DRIZZLE_MIGRATIONS_PATH
   ? resolve(process.cwd(), process.env.DRIZZLE_MIGRATIONS_PATH)
   : resolve(process.cwd(), "drizzle");
 
+let migrationPromise: Promise<void> | null = null;
+
 /**
- * Automatically run database migrations on startup so we don't rely on manual CLI steps.
- * Exported promise allows callers to await readiness.
+ * Run database migrations. Call this on app startup.
+ * Safe to call multiple times - migrations only run once.
  */
-export const dbReady = migrate(db, {
-  migrationsFolder,
-}).catch(error => {
-  console.error("Failed to run database migrations", error);
-  throw error;
-});
+export function runMigrations(): Promise<void> {
+  if (!migrationPromise) {
+    migrationPromise = migrate(db, {
+      migrationsFolder,
+    }).catch(error => {
+      console.error("Failed to run database migrations", error);
+      throw error;
+    });
+  }
+  return migrationPromise;
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -5,7 +5,7 @@ import { makeTownsBot } from "@towns-protocol/bot";
 
 import commands from "./commands";
 import { ALLOWED_EVENT_TYPES } from "./constants";
-import { db, dbReady } from "./db";
+import { db, runMigrations } from "./db";
 import { githubInstallations } from "./db/schema";
 import { GitHubApp } from "./github-app/app";
 import { EventProcessor } from "./github-app/event-processor";
@@ -21,7 +21,7 @@ import { OAuthCleanupService } from "./services/oauth-cleanup-service";
 import { PollingService } from "./services/polling-service";
 import { SubscriptionService } from "./services/subscription-service";
 
-await dbReady;
+await runMigrations();
 console.log("✅ Database ready (schema ensured)");
 
 const bot = await makeTownsBot(


### PR DESCRIPTION
Convert dbReady auto-running promise to explicit runMigrations() function. Prevents migrations from running during tests that import the db module.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Refactored database initialization process to ensure migrations execute reliably at startup with guaranteed single execution.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->