### PR TITLE
refactor: use EventType[] in code layer, string only at DB boundary

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,8 +1,15 @@
+/** Default event types as array for code layer */
+export const DEFAULT_EVENT_TYPES_ARRAY: readonly EventType[] = [
+  "pr",
+  "issues",
+  "commits",
+  "releases",
+];
+
 /**
- * Default event types for GitHub subscriptions
- * This constant is imported and used across the codebase to ensure consistency
+ * Default event types for GitHub subscriptions (string for DB storage)
  */
-export const DEFAULT_EVENT_TYPES = "pr,issues,commits,releases";
+export const DEFAULT_EVENT_TYPES = DEFAULT_EVENT_TYPES_ARRAY.join(",");
 
 /**
  * Allowed event types that users can subscribe to
@@ -25,6 +32,11 @@ export const ALLOWED_EVENT_TYPES = [
  * Event type union extracted from ALLOWED_EVENT_TYPES
  */
 export type EventType = (typeof ALLOWED_EVENT_TYPES)[number];
+
+/** Pre-allocated Set for O(1) event type validation */
+export const ALLOWED_EVENT_TYPES_SET: ReadonlySet<EventType> = new Set(
+  ALLOWED_EVENT_TYPES
+);
 
 /**
  * Pending message cleanup interval (30 seconds)

--- a/src/routes/oauth-callback.ts
+++ b/src/routes/oauth-callback.ts
@@ -1,7 +1,7 @@
 import type { Context } from "hono";
 
 import { getOwnerIdFromUsername, parseRepo } from "../api/github-client";
-import { DEFAULT_EVENT_TYPES } from "../constants";
+import { DEFAULT_EVENT_TYPES_ARRAY } from "../constants";
 import {
   generateInstallUrl,
   type InstallationService,
@@ -70,7 +70,9 @@ export async function handleOAuthCallback(
           spaceId: result.spaceId,
           channelId: result.channelId,
           repoIdentifier: result.redirectData.repo,
-          eventTypes: result.redirectData.eventTypes || DEFAULT_EVENT_TYPES,
+          eventTypes: result.redirectData.eventTypes ?? [
+            ...DEFAULT_EVENT_TYPES_ARRAY,
+          ],
         });
 
         if (subResult.success) {

--- a/src/services/polling-service.ts
+++ b/src/services/polling-service.ts
@@ -329,22 +329,18 @@ export class PollingService {
 /**
  * Check if an event matches the subscription's event type filter
  * @param eventType - GitHub event type (e.g., "PullRequestEvent") or null
- * @param subscriptionTypes - Comma-separated event types (e.g., "pr,issues") or "all" or null
+ * @param subscriptionTypes - Array of event types (e.g., ["pr", "issues"])
  */
 function isEventTypeMatch(
   eventType: string | null,
-  subscriptionTypes: string | null | undefined
+  subscriptionTypes: EventType[]
 ): boolean {
-  // Treat null event type or null/undefined/"all" subscription as match
-  if (!eventType || !subscriptionTypes || subscriptionTypes === "all")
-    return true;
-
-  const subscribedTypes = subscriptionTypes.split(",").map(t => t.trim());
+  // Treat null event type or empty subscription as match-all
+  if (!eventType || subscriptionTypes.length === 0) return true;
 
   // Check if the event type matches any of the subscribed short names
-  for (const shortName of subscribedTypes) {
-    const mappedTypes =
-      EVENT_TYPE_MAP[shortName as EventType]?.split(",") ?? [];
+  for (const shortName of subscriptionTypes) {
+    const mappedTypes = EVENT_TYPE_MAP[shortName]?.split(",") ?? [];
     if (mappedTypes.includes(eventType)) {
       return true;
     }

--- a/src/types/oauth.ts
+++ b/src/types/oauth.ts
@@ -1,13 +1,18 @@
 import { z } from "zod";
 
+import { ALLOWED_EVENT_TYPES } from "../constants";
+
 /** Supported redirect actions after OAuth completion */
 export const RedirectActionSchema = z.enum(["subscribe", "query"]);
 export type RedirectAction = z.infer<typeof RedirectActionSchema>;
 
+/** Event type schema for validation */
+export const EventTypeSchema = z.enum(ALLOWED_EVENT_TYPES);
+
 /** Redirect data passed through OAuth state */
 export const RedirectDataSchema = z.object({
   repo: z.string(),
-  eventTypes: z.string().optional(),
+  eventTypes: z.array(EventTypeSchema).optional(),
   messageEventId: z.string().optional(),
 });
 export type RedirectData = z.infer<typeof RedirectDataSchema>;

--- a/src/views/oauth-pages.ts
+++ b/src/views/oauth-pages.ts
@@ -188,7 +188,7 @@ function renderWebhookSuccess(
   sub: Extract<SubscribeResult, { deliveryMode: "webhook" }>
 ) {
   const safeRepo = escapeHtml(sub.repoFullName);
-  const safeEvents = escapeHtml(sub.eventTypes);
+  const safeEvents = escapeHtml(sub.eventTypes.join(", "));
 
   return c.html(`
     <!DOCTYPE html>
@@ -206,7 +206,7 @@ function renderWebhookSuccess(
           </div>
           <h1>✅ Subscribed to ${safeRepo}!</h1>
           <p class="delivery-mode">⚡ Real-time webhook delivery enabled</p>
-          <p><strong>Events:</strong> ${safeEvents.replace(/,/g, ", ")}</p>
+          <p><strong>Events:</strong> ${safeEvents}</p>
           <p class="success-note">You can close this window and return to Towns.</p>
         </div>
       </body>
@@ -222,7 +222,7 @@ function renderPollingSuccess(
   sub: Extract<SubscribeResult, { deliveryMode: "polling" }>
 ) {
   const safeRepo = escapeHtml(sub.repoFullName);
-  const safeEvents = escapeHtml(sub.eventTypes);
+  const safeEvents = escapeHtml(sub.eventTypes.join(", "));
   const safeInstallUrl = escapeHtml(sub.installUrl);
 
   return c.html(`
@@ -241,7 +241,7 @@ function renderPollingSuccess(
           </div>
           <h1>✅ Subscribed to ${safeRepo}!</h1>
           <p class="delivery-mode">⏱️ Currently using 5-minute polling</p>
-          <p><strong>Events:</strong> ${safeEvents.replace(/,/g, ", ")}</p>
+          <p><strong>Events:</strong> ${safeEvents}</p>
           <div class="install-section">
             <p>💡 <strong>Want real-time updates?</strong></p>
             <a href="${safeInstallUrl}" class="install-button">Install GitHub App</a>

--- a/tests/unit/handlers/github-subscription-handler.test.ts
+++ b/tests/unit/handlers/github-subscription-handler.test.ts
@@ -3,6 +3,7 @@ import { beforeEach, describe, expect, mock, test } from "bun:test";
 import {
   ALLOWED_EVENT_TYPES,
   DEFAULT_EVENT_TYPES,
+  type EventType,
 } from "../../../src/constants";
 import { handleGithubSubscription } from "../../../src/handlers/github-subscription-handler";
 import { TokenStatus } from "../../../src/services/github-oauth-service";
@@ -121,7 +122,11 @@ describe("github subscription handler", () => {
     test("should handle case-insensitive actions - status", async () => {
       mockSubscriptionService.getChannelSubscriptions = mock(() =>
         Promise.resolve([
-          { repo: "owner/repo", eventTypes: DEFAULT_EVENT_TYPES },
+          {
+            repo: "owner/repo",
+            eventTypes: DEFAULT_EVENT_TYPES.split(",") as EventType[],
+            deliveryMode: "webhook",
+          },
         ])
       );
 
@@ -193,7 +198,7 @@ describe("github subscription handler", () => {
         spaceId: "test-space",
         channelId: "test-channel",
         repoIdentifier: "facebook/react",
-        eventTypes: DEFAULT_EVENT_TYPES,
+        eventTypes: DEFAULT_EVENT_TYPES.split(","),
       });
 
       const message = mockHandler.sendMessage.mock.calls[0][1];
@@ -211,7 +216,7 @@ describe("github subscription handler", () => {
       );
 
       const createCalls = mockSubscriptionService.createSubscription.mock.calls;
-      expect(createCalls[0][0].eventTypes).toBe("pr,ci");
+      expect(createCalls[0][0].eventTypes).toEqual(["pr", "ci"]);
     });
 
     test("should handle --events=all flag", async () => {
@@ -225,7 +230,7 @@ describe("github subscription handler", () => {
       );
 
       const createCalls = mockSubscriptionService.createSubscription.mock.calls;
-      expect(createCalls[0][0].eventTypes).toBe(ALLOWED_EVENT_TYPES.join(","));
+      expect(createCalls[0][0].eventTypes).toEqual([...ALLOWED_EVENT_TYPES]);
     });
 
     test("should reject invalid event types", async () => {
@@ -564,12 +569,12 @@ describe("github subscription handler", () => {
         Promise.resolve([
           {
             repo: "owner/repo1",
-            eventTypes: DEFAULT_EVENT_TYPES,
+            eventTypes: DEFAULT_EVENT_TYPES.split(",") as EventType[],
             deliveryMode: "webhook",
           },
           {
             repo: "owner/repo2",
-            eventTypes: "pr,ci",
+            eventTypes: ["pr", "ci"] as EventType[],
             deliveryMode: "polling",
           },
         ])


### PR DESCRIPTION
- Add DEFAULT_EVENT_TYPES_ARRAY and ALLOWED_EVENT_TYPES_SET constants
- Change SubscribeParams.eventTypes from string to EventType[]
- Update parseEventTypes() to return EventType[] directly
- Update formatEventTypes() to accept EventType[]
- Update isEventTypeMatch() to accept EventType[]
- Extract requiresInstallationFailure() helper to reduce duplication
- Update oauth types to use z.enum(ALLOWED_EVENT_TYPES)
- Convert to/from string only at database boundaries

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Improved type safety and data handling for event subscriptions, yielding more consistent validation and processing.
  * Optimized event-type structures for faster, more reliable filtering.

* **Bug Fixes**
  * Fixed subscription matching so empty selections behave as match-all and validation is more efficient.

* **UI**
  * Consistent, properly escaped display of selected event types on OAuth success pages.

* **Tests**
  * Updated tests to reflect array-based event-type handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->