### PR TITLE
docs: add branch-specific filtering and thread grouping brainstorms

### DIFF
--- a/GITHUB_APP_IMPLEMENTATION_PLAN.md
+++ b/GITHUB_APP_IMPLEMENTATION_PLAN.md
@@ -265,6 +265,7 @@ Check if GitHub App installed on repo
 ```
 
 **Pending Subscriptions:**
+
 - Stored in `pending_subscriptions` table with 1-hour expiration
 - Auto-completed when installation webhook fires for the target repo
 - Cleaned up periodically by `cleanupExpiredPendingSubscriptions()`
@@ -322,6 +323,7 @@ User has OAuth token?
 ```
 
 **Second invocation after OAuth + install:**
+
 ```text
 /gh_pr owner/repo #123
   ↓
@@ -332,6 +334,7 @@ Fetch and display result → SUCCESS
 ```
 
 **Key differences from subscriptions:**
+
 - Query commands cannot be "pended" and auto-completed by webhooks
 - Results must be returned synchronously to the user
 - Users must re-run the command after OAuth + install complete
@@ -389,6 +392,9 @@ Located at `github-app-manifest.json`. Key settings:
 - Case-insensitive unsubscribe
 - Ephemeral OAuth URLs for security
 - Pending subscriptions for private repos (auto-complete on install)
+- OAuth token renewal - automatic refresh via `oauth.refreshToken()` with 5-minute buffer
+- Granular unsubscribe - `/github unsubscribe owner/repo --events pr,issues`
+- Subscription management - `/github subscribe owner/repo --events releases` adds to existing
 
 **Documentation:**
 
@@ -398,21 +404,6 @@ Located at `github-app-manifest.json`. Key settings:
 - Condensed AGENTS.md reference
 
 ### 🚧 Remaining Work
-
-### Priority: OAuth Token Renewal
-
-OAuth tokens expire and users are currently prompted to reauthorize. Implement automatic token refresh:
-
-- Store `refreshToken` and `refreshTokenExpiresAt` (schema already has columns)
-- Before API calls, check if access token is expired
-- Use `oauth.refreshToken()` to get new access token
-- Update stored token in database
-- Fall back to reauthorization prompt only if refresh fails
-
-**Subscription & UX:**
-
-- Granular unsubscribe - remove selected event types without dropping the repo
-- Subscription management - update event filters for existing subscriptions
 
 **Event Organization:**
 
@@ -559,6 +550,165 @@ A fun statistics command for repository insights and contributor leaderboards.
 
 📈 Activity: 156 commits this week (↑12% vs last week)
 ```
+
+### Thread-Based Event Grouping Brainstorm
+
+Group related GitHub events into threads to reduce channel noise while preserving context.
+
+**Core Concept:**
+
+When a PR is opened, subsequent events (commits, CI runs, reviews, comments) are sent as thread replies instead of top-level messages. This keeps the channel clean while grouping all PR activity together.
+
+**Event Grouping Strategy:**
+
+| Thread Anchor     | Grouped Events                                                                     |
+| ----------------- | ---------------------------------------------------------------------------------- |
+| PR opened         | Commits pushed, CI status, reviews, review comments, PR comments, PR merged/closed |
+| Issue opened      | Issue comments, issue closed/reopened                                              |
+| Release published | (standalone - no grouping needed)                                                  |
+| Branch created    | Commits pushed to branch (optional)                                                |
+
+**Implementation Approach:**
+
+1. **Thread ID Tracking Table:**
+
+```sql
+CREATE TABLE event_threads (
+  id SERIAL PRIMARY KEY,
+  space_id TEXT NOT NULL,
+  channel_id TEXT NOT NULL,
+  repo_full_name TEXT NOT NULL,
+  anchor_type TEXT NOT NULL,        -- 'pr' | 'issue'
+  anchor_number INTEGER NOT NULL,   -- PR/issue number
+  thread_event_id TEXT NOT NULL,    -- Towns eventId of anchor message
+  created_at TIMESTAMPTZ NOT NULL,
+  expires_at TIMESTAMPTZ NOT NULL,  -- Auto-cleanup after 30 days
+  UNIQUE(space_id, channel_id, repo_full_name, anchor_type, anchor_number)
+);
+```
+
+2. **Event Processing Flow:**
+
+```
+Incoming webhook event
+  ↓
+Is this a PR/issue event?
+  ├─ PR opened / Issue opened → Send as top-level, store thread_event_id
+  └─ PR push / PR review / PR comment / etc.
+       ↓
+     Lookup thread_event_id for this PR number
+       ├─ Found → Send as reply with threadId
+       └─ Not found → Send as top-level (anchor was before bot joined)
+```
+
+3. **Handler Changes:**
+
+- Modify `EventProcessor` to check for existing thread before sending
+- Add `threadId` option to message sending
+- Store thread anchor on PR/issue open events
+
+**Message Format in Thread:**
+
+```text
+# Anchor message (top-level)
+🔀 **PR #123 opened** by @user
+feat: Add dark mode support
+[View PR](https://github.com/...)
+
+# Thread replies
+💬 @reviewer commented on PR #123
+"Looks good! Just one suggestion..."
+
+✅ CI passed on PR #123
+All 45 tests passing
+
+🔍 @reviewer approved PR #123
+"LGTM!"
+
+🎉 PR #123 merged by @user
+```
+
+**Configuration Options:**
+
+```bash
+/github subscribe owner/repo --threads=on   # Enable threading (default)
+/github subscribe owner/repo --threads=off  # All events top-level
+```
+
+Or per-event-type:
+
+```bash
+/github subscribe owner/repo --thread-pr --no-thread-issues
+```
+
+**Edge Cases:**
+
+1. **Late joins**: If bot wasn't present when PR opened, send as top-level
+2. **Thread expiration**: Clean up thread mappings after 30 days
+3. **High-volume repos**: Consider thread limits (Towns may have constraints)
+4. **Cross-channel**: Same PR subscribed in multiple channels = separate threads
+
+**Data Retention:**
+
+- Thread mappings expire after 30 days (configurable)
+- Cleanup job runs daily to remove expired entries
+- No impact on message history (Towns retains messages independently)
+
+**Limitations:**
+
+- Requires Towns Protocol thread support (verify API availability)
+- Cannot retroactively thread old events
+- Thread lookup adds ~1 DB query per event (index on composite key)
+
+### Branch-Specific Event Filtering Brainstorm
+
+Filter events by branch to reduce noise from feature branches.
+
+**Syntax:**
+
+```bash
+/github subscribe owner/repo --events commits --branches main,develop
+/github subscribe owner/repo --events commits,ci --branches release/*
+/github subscribe owner/repo --events commits --branches all  # Opt-in to all branches (or *)
+```
+
+**Scope - Events affected by `--branches` flag:**
+
+| Event    | Branch Context             | Example Use Case         |
+| -------- | -------------------------- | ------------------------ |
+| commits  | Branch pushed to           | Only main/develop pushes |
+| ci       | Workflow trigger branch    | Only prod CI results     |
+| pr       | Base branch (merge target) | Only PRs targeting main  |
+| reviews  | PR's base branch           | Same as pr               |
+| branches | Branch created/deleted     | Only release/\* events   |
+
+**Not branch-specific:** issues, comments, releases, stars, forks
+
+**Design Decisions:**
+
+- Default: **Default branch only** (breaking change from current "all branches")
+- Patterns: **Glob support** (`release/*`, `feature/*`)
+- `--branches all` opts into all branches (preserves old behavior)
+
+**Storage:**
+
+New `branch_filter` column in `github_subscriptions`:
+
+- `NULL` = default branch only
+- `'all'` = all branches
+- `'main,develop,release/*'` = specific branches/patterns
+
+**Files to modify:**
+
+1. `db/schema.ts` - Add `branch_filter` column
+2. `github-subscription-handler.ts` - Parse `--branches` flag
+3. `event-processor.ts` - Filter in specific handlers (`onPush`, `onWorkflowRun`, `onPullRequest`, `onPullRequestReview`, `onBranchEvent`) using typed payloads from `@octokit/webhooks`
+4. `subscription-service.ts` - Store/retrieve filter
+
+**Migration:**
+
+Breaking change: existing subscriptions get default-branch-only behavior.
+Option: migrate existing commits subscriptions to `branch_filter = 'all'` to preserve old behavior.
 
 ## References
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,6 @@ All webhook events above, plus:
 - **No interactive actions** - Towns Protocol doesn't support buttons/forms yet
 - **No threaded conversations** - All notifications sent as top-level messages
 - **5-minute polling delay** - Without GitHub App, events have 5-minute latency
-- **OAuth token expiration** - Users may need to reauthorize periodically (token refresh not yet implemented)
 
 ## Future Enhancements
 
@@ -224,18 +223,13 @@ All webhook events above, plus:
 - [x] Improved subscription UX - Single OAuth flow with immediate subscription creation
 - [x] Enhanced OAuth success page - Installation countdown and auto-redirect
 - [x] Pending subscriptions for private repos - Auto-complete when GitHub App is installed
-
-### Priority
-
-- [ ] OAuth token renewal - Automatically refresh expired tokens instead of prompting reauthorization
-
-### Subscription & UX
-
-- [ ] Granular unsubscribe - Unsubscribe from specific event types without removing entire repo subscription
-- [ ] Subscription management - Update event filters for existing subscriptions
+- [x] OAuth token renewal - Automatic refresh with 5-minute buffer before expiration
+- [x] Granular unsubscribe - `/github unsubscribe owner/repo --events pr,issues`
+- [x] Subscription management - `/github subscribe owner/repo --events releases` adds to existing
 
 ### Event Organization
 
+- [ ] Branch-specific filtering - `--branches main,release/*` to filter commits, CI, PRs by branch
 - [ ] Thread-based event grouping - Group related events (PR + commits + CI) in threads to reduce channel noise
 - [ ] Event summaries - Digest multiple events into single update message
 


### PR DESCRIPTION
- Mark completed: OAuth token renewal, granular unsubscribe, subscription management
- Add branch-specific event filtering design (--branches flag)
- Add thread-based event grouping design
- Document filtering in specific handlers using @octokit/webhooks types

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated documentation for thread-based event grouping to organize related GitHub events and reduce channel noise.
  * Added branch-specific event filtering capabilities.
  * Clarified OAuth token automatic renewal behavior.
  * Enhanced subscription and unsubscribe command documentation.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->