### PR TITLE
refactor: require all GitHub App env vars and remove isEnabled

### DIFF
--- a/src/github-app/app.ts
+++ b/src/github-app/app.ts
@@ -20,16 +20,17 @@ export class GitHubApp {
     const clientSecret = process.env.GITHUB_APP_CLIENT_SECRET;
     const webhookSecret = process.env.GITHUB_WEBHOOK_SECRET;
 
-    // Check if GitHub App is configured
-    if (!appId || !privateKeyBase64 || !webhookSecret) {
-      console.warn("GitHub App not configured - webhook mode disabled");
-      console.warn(
-        "Set GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY_BASE64, and GITHUB_WEBHOOK_SECRET to enable"
+    // Require GitHub App configuration
+    if (
+      !appId ||
+      !privateKeyBase64 ||
+      !clientId ||
+      !clientSecret ||
+      !webhookSecret
+    ) {
+      throw new Error(
+        "GitHub App not configured. Set GITHUB_APP_ID, GITHUB_APP_PRIVATE_KEY_BASE64, GITHUB_APP_CLIENT_ID, GITHUB_APP_CLIENT_SECRET, and GITHUB_WEBHOOK_SECRET"
       );
-      // Create dummy instances to avoid errors
-      this.app = null as any;
-      this.webhooks = null as any;
-      return;
     }
 
     // Decode base64 private key
@@ -39,13 +40,7 @@ export class GitHubApp {
     this.app = new App({
       appId,
       privateKey,
-      oauth:
-        clientId && clientSecret
-          ? {
-              clientId,
-              clientSecret,
-            }
-          : undefined,
+      oauth: { clientId, clientSecret },
     });
 
     // Initialize Webhooks handler
@@ -67,27 +62,13 @@ export class GitHubApp {
    * @returns JWT-authenticated Octokit instance
    */
   getAppOctokit(): Octokit {
-    if (!this.app) {
-      throw new Error("GitHub App not configured");
-    }
     return this.app.octokit;
   }
 
   /**
-   * Check if GitHub App is configured and enabled
-   */
-  isEnabled(): boolean {
-    return this.app !== null && this.webhooks !== null;
-  }
-
-  /**
    * Get OAuth instance for user authentication
-   * Returns undefined if OAuth is not configured
    */
   getOAuth() {
-    if (!this.app) {
-      return undefined;
-    }
     return this.app.oauth;
   }
 }

--- a/src/github-app/installation-service.ts
+++ b/src/github-app/installation-service.ts
@@ -251,10 +251,6 @@ export class InstallationService {
     repo: string
   ): Promise<number | null> {
     try {
-      if (!this.githubApp.isEnabled()) {
-        return null;
-      }
-
       const octokit = this.githubApp.getAppOctokit();
       const { data } = await octokit.request(
         "GET /repos/{owner}/{repo}/installation",
@@ -381,10 +377,6 @@ export class InstallationService {
     );
 
     try {
-      if (!this.githubApp.isEnabled()) {
-        throw new Error("GitHub App not configured");
-      }
-
       // Use app-authenticated Octokit (JWT) for app-level endpoint
       const octokit = this.githubApp.getAppOctokit();
       const { data: installation } = await octokit.request(

--- a/src/index.ts
+++ b/src/index.ts
@@ -62,72 +62,68 @@ const pollingService = new PollingService(
   5 * 60 * 1000
 );
 
-// Register webhook event handlers (only if GitHub App is configured)
-if (githubApp.isEnabled()) {
-  githubApp.webhooks.on("installation", async ({ payload }) => {
-    if (payload.action === "created") {
-      await installationService.onInstallationCreated(payload);
-    } else if (payload.action === "deleted") {
-      await installationService.onInstallationDeleted(payload);
-    }
-  });
+// Register webhook event handlers
+githubApp.webhooks.on("installation", async ({ payload }) => {
+  if (payload.action === "created") {
+    await installationService.onInstallationCreated(payload);
+  } else if (payload.action === "deleted") {
+    await installationService.onInstallationDeleted(payload);
+  }
+});
 
-  githubApp.webhooks.on("installation_repositories", async ({ payload }) => {
-    if (payload.action === "added") {
-      await installationService.onRepositoriesAdded(payload);
-    } else if (payload.action === "removed") {
-      await installationService.onRepositoriesRemoved(payload);
-    }
-  });
+githubApp.webhooks.on("installation_repositories", async ({ payload }) => {
+  if (payload.action === "added") {
+    await installationService.onRepositoriesAdded(payload);
+  } else if (payload.action === "removed") {
+    await installationService.onRepositoriesRemoved(payload);
+  }
+});
 
-  githubApp.webhooks.on("pull_request", async ({ payload }) => {
-    await eventProcessor.onPullRequest(payload);
-  });
+githubApp.webhooks.on("pull_request", async ({ payload }) => {
+  await eventProcessor.onPullRequest(payload);
+});
 
-  githubApp.webhooks.on("push", async ({ payload }) => {
-    await eventProcessor.onPush(payload);
-  });
+githubApp.webhooks.on("push", async ({ payload }) => {
+  await eventProcessor.onPush(payload);
+});
 
-  githubApp.webhooks.on("issues", async ({ payload }) => {
-    await eventProcessor.onIssues(payload);
-  });
+githubApp.webhooks.on("issues", async ({ payload }) => {
+  await eventProcessor.onIssues(payload);
+});
 
-  githubApp.webhooks.on("release", async ({ payload }) => {
-    await eventProcessor.onRelease(payload);
-  });
+githubApp.webhooks.on("release", async ({ payload }) => {
+  await eventProcessor.onRelease(payload);
+});
 
-  githubApp.webhooks.on("workflow_run", async ({ payload }) => {
-    await eventProcessor.onWorkflowRun(payload);
-  });
+githubApp.webhooks.on("workflow_run", async ({ payload }) => {
+  await eventProcessor.onWorkflowRun(payload);
+});
 
-  githubApp.webhooks.on("issue_comment", async ({ payload }) => {
-    await eventProcessor.onIssueComment(payload);
-  });
+githubApp.webhooks.on("issue_comment", async ({ payload }) => {
+  await eventProcessor.onIssueComment(payload);
+});
 
-  githubApp.webhooks.on("pull_request_review", async ({ payload }) => {
-    await eventProcessor.onPullRequestReview(payload);
-  });
+githubApp.webhooks.on("pull_request_review", async ({ payload }) => {
+  await eventProcessor.onPullRequestReview(payload);
+});
 
-  githubApp.webhooks.on("create", async ({ payload }) => {
-    await eventProcessor.onBranchEvent(payload, "create");
-  });
+githubApp.webhooks.on("create", async ({ payload }) => {
+  await eventProcessor.onBranchEvent(payload, "create");
+});
 
-  githubApp.webhooks.on("delete", async ({ payload }) => {
-    await eventProcessor.onBranchEvent(payload, "delete");
-  });
+githubApp.webhooks.on("delete", async ({ payload }) => {
+  await eventProcessor.onBranchEvent(payload, "delete");
+});
 
-  githubApp.webhooks.on("fork", async ({ payload }) => {
-    await eventProcessor.onFork(payload);
-  });
+githubApp.webhooks.on("fork", async ({ payload }) => {
+  await eventProcessor.onFork(payload);
+});
 
-  githubApp.webhooks.on("watch", async ({ payload }) => {
-    await eventProcessor.onWatch(payload);
-  });
+githubApp.webhooks.on("watch", async ({ payload }) => {
+  await eventProcessor.onWatch(payload);
+});
 
-  console.log("✅ GitHub App webhooks registered");
-} else {
-  console.log("⚠️  GitHub App not configured - running in polling-only mode");
-}
+console.log("✅ GitHub App webhooks registered");
 
 // ============================================================================
 // SLASH COMMAND HANDLERS
@@ -215,20 +211,16 @@ app.post("/github-webhook", c =>
 app.get("/health", async c => {
   const repos = await subscriptionService.getAllSubscribedRepos();
 
-  // Get GitHub App installation count if enabled
-  let installationCount = 0;
-  if (githubApp.isEnabled()) {
-    const installations = await db.select().from(githubInstallations);
-    installationCount = installations.length;
-  }
+  // Get GitHub App installation count
+  const installations = await db.select().from(githubInstallations);
 
   return c.json({
     status: "ok",
     subscribed_repos: repos.length,
     polling_active: true,
     github_app: {
-      configured: githubApp.isEnabled(),
-      installations: installationCount,
+      configured: true,
+      installations: installations.length,
     },
   });
 });

--- a/src/routes/github-webhook.ts
+++ b/src/routes/github-webhook.ts
@@ -8,10 +8,6 @@ export async function handleGitHubWebhook(
   githubApp: GitHubApp,
   webhookProcessor: WebhookProcessor
 ) {
-  if (!githubApp.isEnabled()) {
-    return c.json({ error: "GitHub App not configured" }, 503);
-  }
-
   const deliveryId = c.req.header("x-github-delivery");
   const signature = c.req.header("x-hub-signature-256");
   const event = c.req.header("x-github-event");

--- a/src/services/github-oauth-service.ts
+++ b/src/services/github-oauth-service.ts
@@ -128,12 +128,7 @@ export class GitHubOAuthService {
     });
 
     // Use Octokit's OAuth to generate authorization URL
-    const oauth = this.githubApp.getOAuth();
-    if (!oauth) {
-      throw new Error("OAuth not configured");
-    }
-
-    const { url } = oauth.getWebFlowAuthorizationUrl({
+    const { url } = this.githubApp.getOAuth().getWebFlowAuthorizationUrl({
       state,
       redirectUrl: this.redirectUrl,
     });
@@ -172,10 +167,6 @@ export class GitHubOAuthService {
 
     // Exchange code for token using Octokit
     const oauth = this.githubApp.getOAuth();
-    if (!oauth) {
-      throw new Error("OAuth not configured");
-    }
-
     const { authentication } = await oauth.createToken({
       code,
       state,
@@ -338,10 +329,7 @@ export class GitHubOAuthService {
 
     // Revoke token on GitHub (optional - token will be invalidated anyway)
     try {
-      const oauth = this.githubApp.getOAuth();
-      if (oauth) {
-        await oauth.deleteToken({ token: token.accessToken });
-      }
+      await this.githubApp.getOAuth().deleteToken({ token: token.accessToken });
     } catch (error) {
       console.error("Failed to revoke token on GitHub:", error);
       // Continue with local deletion even if revocation fails
@@ -456,13 +444,10 @@ export class GitHubOAuthService {
     }
 
     try {
-      const oauth = this.githubApp.getOAuth();
-      if (!oauth) {
-        throw new Error("OAuth not configured");
-      }
-
       // Use Octokit's refreshToken method
-      const { authentication } = await oauth.refreshToken({ refreshToken });
+      const { authentication } = await this.githubApp
+        .getOAuth()
+        .refreshToken({ refreshToken });
 
       // Update stored tokens
       await db


### PR DESCRIPTION
- Constructor throws if any env var is missing (fail fast)
- Require GITHUB_APP_CLIENT_ID and GITHUB_APP_CLIENT_SECRET
- Remove isEnabled() method and all call sites
- Remove unnecessary oauth null checks in GitHubOAuthService

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Configuration validation is stricter: missing GitHub credentials now produce explicit errors.
  * OAuth and API calls no longer short-circuit on missing config, so runtime errors may surface during operations.

* **Chores**
  * Webhooks are registered and processed unconditionally at startup.
  * Health endpoint now reports the app as configured and reflects total installations.
  * Removed the public isEnabled() check.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->