### PR TITLE
feat: add thread-based event grouping for PRs and issues

### DIFF
--- a/drizzle/0006_certain_micromacro.sql
+++ b/drizzle/0006_certain_micromacro.sql
@@ -1,0 +1,16 @@
+CREATE TABLE "event_threads" (
+	"id" serial PRIMARY KEY NOT NULL,
+	"space_id" text NOT NULL,
+	"channel_id" text NOT NULL,
+	"repo_full_name" text NOT NULL,
+	"anchor_type" text NOT NULL,
+	"anchor_number" integer NOT NULL,
+	"thread_event_id" text NOT NULL,
+	"created_at" timestamp with time zone NOT NULL,
+	"expires_at" timestamp with time zone NOT NULL,
+	CONSTRAINT "anchor_type_check" CHECK ("event_threads"."anchor_type" IN ('pr', 'issue'))
+);
+--> statement-breakpoint
+CREATE UNIQUE INDEX "event_threads_unique_idx" ON "event_threads" USING btree ("space_id","channel_id","repo_full_name","anchor_type","anchor_number");--> statement-breakpoint
+CREATE INDEX "idx_event_threads_repo_anchor" ON "event_threads" USING btree ("repo_full_name","anchor_type","anchor_number");--> statement-breakpoint
+CREATE INDEX "idx_event_threads_expires" ON "event_threads" USING btree ("expires_at");

--- a/drizzle/meta/0006_snapshot.json
+++ b/drizzle/meta/0006_snapshot.json
@@ -1,0 +1,963 @@
+{
+  "id": "64e2be0e-e932-428c-a783-360d02b82ff1",
+  "prevId": "7e8206de-d629-4058-9115-5ff2bb607d75",
+  "version": "7",
+  "dialect": "postgresql",
+  "tables": {
+    "public.event_threads": {
+      "name": "event_threads",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_type": {
+          "name": "anchor_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "anchor_number": {
+          "name": "anchor_number",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "thread_event_id": {
+          "name": "thread_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "event_threads_unique_idx": {
+          "name": "event_threads_unique_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "anchor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "anchor_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_threads_repo_anchor": {
+          "name": "idx_event_threads_repo_anchor",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "anchor_type",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "anchor_number",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_event_threads_expires": {
+          "name": "idx_event_threads_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "anchor_type_check": {
+          "name": "anchor_type_check",
+          "value": "\"event_threads\".\"anchor_type\" IN ('pr', 'issue')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_installations": {
+      "name": "github_installations",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "account_login": {
+          "name": "account_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "account_type": {
+          "name": "account_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "installed_at": {
+          "name": "installed_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "suspended_at": {
+          "name": "suspended_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "app_slug": {
+          "name": "app_slug",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'towns-github-bot'"
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "account_type_check": {
+          "name": "account_type_check",
+          "value": "\"github_installations\".\"account_type\" IN ('Organization', 'User')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_subscriptions": {
+      "name": "github_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivery_mode": {
+          "name": "delivery_mode",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "is_private": {
+          "name": "is_private",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_towns_user_id": {
+          "name": "created_by_towns_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_by_github_login": {
+          "name": "created_by_github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "enabled": {
+          "name": "enabled",
+          "type": "boolean",
+          "primaryKey": false,
+          "notNull": true,
+          "default": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pr,issues,commits,releases'"
+        },
+        "branch_filter": {
+          "name": "branch_filter",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_subscriptions_unique_idx": {
+          "name": "github_subscriptions_unique_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_subscriptions_channel": {
+          "name": "idx_github_subscriptions_channel",
+          "columns": [
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_github_subscriptions_repo": {
+          "name": "idx_github_subscriptions_repo",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "github_subscriptions_created_by_towns_user_id_github_user_tokens_towns_user_id_fk": {
+          "name": "github_subscriptions_created_by_towns_user_id_github_user_tokens_towns_user_id_fk",
+          "tableFrom": "github_subscriptions",
+          "tableTo": "github_user_tokens",
+          "columnsFrom": [
+            "created_by_towns_user_id"
+          ],
+          "columnsTo": [
+            "towns_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        },
+        "github_subscriptions_installation_id_github_installations_installation_id_fk": {
+          "name": "github_subscriptions_installation_id_github_installations_installation_id_fk",
+          "tableFrom": "github_subscriptions",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "installation_id"
+          ],
+          "onDelete": "set null",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "delivery_mode_check": {
+          "name": "delivery_mode_check",
+          "value": "\"github_subscriptions\".\"delivery_mode\" IN ('webhook', 'polling')"
+        }
+      },
+      "isRLSEnabled": false
+    },
+    "public.github_user_tokens": {
+      "name": "github_user_tokens",
+      "schema": "",
+      "columns": {
+        "towns_user_id": {
+          "name": "towns_user_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "github_user_id": {
+          "name": "github_user_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "github_login": {
+          "name": "github_login",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "access_token": {
+          "name": "access_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "token_type": {
+          "name": "token_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token": {
+          "name": "refresh_token",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "refresh_token_expires_at": {
+          "name": "refresh_token_expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "github_user_tokens_github_user_id_unique": {
+          "name": "github_user_tokens_github_user_id_unique",
+          "columns": [
+            {
+              "expression": "github_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.installation_repositories": {
+      "name": "installation_repositories",
+      "schema": "",
+      "columns": {
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "added_at": {
+          "name": "added_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_installation_repos_by_name": {
+          "name": "idx_installation_repos_by_name",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_installation_repos_by_install": {
+          "name": "idx_installation_repos_by_install",
+          "columns": [
+            {
+              "expression": "installation_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "installation_repositories_installation_id_github_installations_installation_id_fk": {
+          "name": "installation_repositories_installation_id_github_installations_installation_id_fk",
+          "tableFrom": "installation_repositories",
+          "tableTo": "github_installations",
+          "columnsFrom": [
+            "installation_id"
+          ],
+          "columnsTo": [
+            "installation_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {
+        "installation_repositories_installation_id_repo_full_name_pk": {
+          "name": "installation_repositories_installation_id_repo_full_name_pk",
+          "columns": [
+            "installation_id",
+            "repo_full_name"
+          ]
+        }
+      },
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.oauth_states": {
+      "name": "oauth_states",
+      "schema": "",
+      "columns": {
+        "state": {
+          "name": "state",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "towns_user_id": {
+          "name": "towns_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "redirect_action": {
+          "name": "redirect_action",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "redirect_data": {
+          "name": "redirect_data",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_oauth_states_expires": {
+          "name": "idx_oauth_states_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_oauth_states_towns_user_id": {
+          "name": "idx_oauth_states_towns_user_id",
+          "columns": [
+            {
+              "expression": "towns_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.pending_subscriptions": {
+      "name": "pending_subscriptions",
+      "schema": "",
+      "columns": {
+        "id": {
+          "name": "id",
+          "type": "serial",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "towns_user_id": {
+          "name": "towns_user_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "space_id": {
+          "name": "space_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "channel_id": {
+          "name": "channel_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "repo_full_name": {
+          "name": "repo_full_name",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "event_types": {
+          "name": "event_types",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "created_at": {
+          "name": "created_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "expires_at": {
+          "name": "expires_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {
+        "idx_pending_subscriptions_expires": {
+          "name": "idx_pending_subscriptions_expires",
+          "columns": [
+            {
+              "expression": "expires_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_subscriptions_user": {
+          "name": "idx_pending_subscriptions_user",
+          "columns": [
+            {
+              "expression": "towns_user_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "idx_pending_subscriptions_repo": {
+          "name": "idx_pending_subscriptions_repo",
+          "columns": [
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        },
+        "pending_subscriptions_unique_idx": {
+          "name": "pending_subscriptions_unique_idx",
+          "columns": [
+            {
+              "expression": "space_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "channel_id",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "repo_full_name",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": true,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {
+        "pending_subscriptions_towns_user_id_github_user_tokens_towns_user_id_fk": {
+          "name": "pending_subscriptions_towns_user_id_github_user_tokens_towns_user_id_fk",
+          "tableFrom": "pending_subscriptions",
+          "tableTo": "github_user_tokens",
+          "columnsFrom": [
+            "towns_user_id"
+          ],
+          "columnsTo": [
+            "towns_user_id"
+          ],
+          "onDelete": "cascade",
+          "onUpdate": "no action"
+        }
+      },
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.repo_polling_state": {
+      "name": "repo_polling_state",
+      "schema": "",
+      "columns": {
+        "repo": {
+          "name": "repo",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "etag": {
+          "name": "etag",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_event_id": {
+          "name": "last_event_id",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "last_polled_at": {
+          "name": "last_polled_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "default_branch": {
+          "name": "default_branch",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "updated_at": {
+          "name": "updated_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        }
+      },
+      "indexes": {},
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {},
+      "isRLSEnabled": false
+    },
+    "public.webhook_deliveries": {
+      "name": "webhook_deliveries",
+      "schema": "",
+      "columns": {
+        "delivery_id": {
+          "name": "delivery_id",
+          "type": "text",
+          "primaryKey": true,
+          "notNull": true
+        },
+        "installation_id": {
+          "name": "installation_id",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "event_type": {
+          "name": "event_type",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "delivered_at": {
+          "name": "delivered_at",
+          "type": "timestamp with time zone",
+          "primaryKey": false,
+          "notNull": true
+        },
+        "status": {
+          "name": "status",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": true,
+          "default": "'pending'"
+        },
+        "error": {
+          "name": "error",
+          "type": "text",
+          "primaryKey": false,
+          "notNull": false
+        },
+        "retry_count": {
+          "name": "retry_count",
+          "type": "integer",
+          "primaryKey": false,
+          "notNull": true,
+          "default": 0
+        }
+      },
+      "indexes": {
+        "idx_deliveries_status": {
+          "name": "idx_deliveries_status",
+          "columns": [
+            {
+              "expression": "status",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            },
+            {
+              "expression": "delivered_at",
+              "isExpression": false,
+              "asc": true,
+              "nulls": "last"
+            }
+          ],
+          "isUnique": false,
+          "concurrently": false,
+          "method": "btree",
+          "with": {}
+        }
+      },
+      "foreignKeys": {},
+      "compositePrimaryKeys": {},
+      "uniqueConstraints": {},
+      "policies": {},
+      "checkConstraints": {
+        "status_check": {
+          "name": "status_check",
+          "value": "\"webhook_deliveries\".\"status\" IN ('pending', 'success', 'failed')"
+        }
+      },
+      "isRLSEnabled": false
+    }
+  },
+  "enums": {},
+  "schemas": {},
+  "sequences": {},
+  "roles": {},
+  "policies": {},
+  "views": {},
+  "_meta": {
+    "columns": {},
+    "schemas": {},
+    "tables": {}
+  }
+}

--- a/drizzle/meta/_journal.json
+++ b/drizzle/meta/_journal.json
@@ -43,6 +43,13 @@
       "when": 1764410325645,
       "tag": "0005_neat_blindfold",
       "breakpoints": true
+    },
+    {
+      "idx": 6,
+      "version": "7",
+      "when": 1764615938698,
+      "tag": "0006_certain_micromacro",
+      "breakpoints": true
     }
   ]
 }

--- a/src/services/subscription-service.ts
+++ b/src/services/subscription-service.ts
@@ -616,6 +616,7 @@ export class SubscriptionService {
     deliveryMode?: "webhook" | "polling"
   ): Promise<
     Array<{
+      spaceId: string;
       channelId: string;
       eventTypes: EventType[];
       branchFilter: BranchFilter;
@@ -629,6 +630,7 @@ export class SubscriptionService {
 
     const results = await db
       .select({
+        spaceId: githubSubscriptions.spaceId,
         channelId: githubSubscriptions.channelId,
         eventTypes: githubSubscriptions.eventTypes,
         branchFilter: githubSubscriptions.branchFilter,
@@ -637,6 +639,7 @@ export class SubscriptionService {
       .where(and(...conditions));
 
     return results.map(r => ({
+      spaceId: r.spaceId,
       channelId: r.channelId,
       eventTypes: parseEventTypes(r.eventTypes),
       branchFilter: r.branchFilter,

--- a/src/services/thread-service.ts
+++ b/src/services/thread-service.ts
@@ -1,0 +1,142 @@
+import { and, eq, gte, lt } from "drizzle-orm";
+
+import { db } from "../db";
+import { eventThreads } from "../db/schema";
+
+export type AnchorType = "pr" | "issue";
+
+/** Default thread expiration: 30 days */
+const DEFAULT_EXPIRY_DAYS = 30;
+
+/**
+ * ThreadService - Manages thread mappings for GitHub event grouping
+ *
+ * Stores mappings from (repo, PR/issue number) to Towns thread IDs,
+ * enabling related events to be sent as thread replies.
+ */
+export class ThreadService {
+  /**
+   * Get the thread event ID for a PR or issue
+   * Returns null if no thread exists (anchor wasn't seen or expired)
+   */
+  async getThreadId(
+    spaceId: string,
+    channelId: string,
+    repoFullName: string,
+    anchorType: AnchorType,
+    anchorNumber: number
+  ): Promise<string | null> {
+    const results = await db
+      .select({ threadEventId: eventThreads.threadEventId })
+      .from(eventThreads)
+      .where(
+        and(
+          eq(eventThreads.spaceId, spaceId),
+          eq(eventThreads.channelId, channelId),
+          eq(eventThreads.repoFullName, repoFullName),
+          eq(eventThreads.anchorType, anchorType),
+          eq(eventThreads.anchorNumber, anchorNumber),
+          gte(eventThreads.expiresAt, new Date()) // Exclude expired threads
+        )
+      )
+      .limit(1);
+
+    return results[0]?.threadEventId ?? null;
+  }
+
+  /**
+   * Store a thread mapping when an anchor event (PR/issue opened) is sent
+   */
+  async storeThread(
+    params: {
+      spaceId: string;
+      channelId: string;
+      repoFullName: string;
+      anchorType: AnchorType;
+      anchorNumber: number;
+      threadEventId: string;
+    },
+    expiryDays = DEFAULT_EXPIRY_DAYS
+  ): Promise<void> {
+    const now = new Date();
+    const expiresAt = new Date(now);
+    expiresAt.setDate(expiresAt.getDate() + expiryDays);
+
+    // Upsert: update if exists, insert if not
+    await db
+      .insert(eventThreads)
+      .values({
+        ...params,
+        createdAt: now,
+        expiresAt,
+      })
+      .onConflictDoUpdate({
+        target: [
+          eventThreads.spaceId,
+          eventThreads.channelId,
+          eventThreads.repoFullName,
+          eventThreads.anchorType,
+          eventThreads.anchorNumber,
+        ],
+        set: {
+          threadEventId: params.threadEventId,
+          expiresAt,
+        },
+      });
+  }
+
+  /**
+   * Delete expired thread mappings
+   * Should be called periodically (e.g., daily cleanup job)
+   */
+  async cleanupExpired(): Promise<number> {
+    const result = await db
+      .delete(eventThreads)
+      .where(lt(eventThreads.expiresAt, new Date()))
+      .returning({ id: eventThreads.id });
+
+    return result.length;
+  }
+
+  /**
+   * Start periodic cleanup of expired thread mappings
+   *
+   * @param intervalMs - Cleanup interval in milliseconds (default: 24 hours)
+   * @returns Timer ID that can be used to stop the cleanup
+   */
+  startPeriodicCleanup(
+    intervalMs: number = 24 * 60 * 60 * 1000
+  ): ReturnType<typeof setInterval> {
+    console.log(
+      `[Thread Cleanup] Starting periodic cleanup (every ${intervalMs / 1000 / 60 / 60} hours)`
+    );
+
+    // Run cleanup immediately on start
+    this.cleanupExpired()
+      .then(count => {
+        if (count > 0) {
+          console.log(
+            `[Thread Cleanup] Removed ${count} expired thread mappings`
+          );
+        }
+      })
+      .catch(error => {
+        console.error("[Thread Cleanup] Initial cleanup failed:", error);
+      });
+
+    // Schedule periodic cleanup
+    return setInterval(() => {
+      this.cleanupExpired()
+        .then(count => {
+          if (count > 0) {
+            console.log(
+              `[Thread Cleanup] Removed ${count} expired thread mappings`
+            );
+          }
+        })
+        .catch(error => {
+          console.error("[Thread Cleanup] Periodic cleanup failed:", error);
+        });
+    }, intervalMs);
+  }
+}


### PR DESCRIPTION
Group related GitHub events into Towns threads to reduce channel noise:
- PR opened events start threads, follow-up events (reviews, comments, merged/closed) reply to them
- Issue opened events start threads, follow-up events (comments, closed/reopened) reply to them

Implementation:
- Add event_threads table to store thread mappings (space, channel, repo, anchor type/number -> Towns eventId)
- ThreadService handles thread lookup/storage with 30-day expiry
- EventProcessor sends anchor events as top-level, follow-ups as replies
- Daily cleanup job removes expired thread mappings

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * GitHub PRs, issues, comments and reviews now group into persistent per-channel discussion threads and reuse thread links.
  * Subscriber deliveries include space context so messages route correctly per space.
  * Delivery flow improved with per-channel threading and more robust error handling.

* **Chores**
  * Persistent thread mappings auto-expire after 30 days and are cleaned up daily by a background service.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->