### PR TITLE
refactor: centralize branch-filterable events as single source of truth

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -39,6 +39,25 @@ export const ALLOWED_EVENT_TYPES_SET: ReadonlySet<EventType> = new Set(
 );
 
 /**
+ * Event types that support branch filtering.
+ * These events have branch context and can be filtered by --branches flag.
+ * Other events (issues, releases, comments, forks, stars) are not branch-specific.
+ */
+export const BRANCH_FILTERABLE_EVENTS: readonly EventType[] = [
+  "pr",
+  "commits",
+  "ci",
+  "reviews",
+  "review_comments",
+  "branches",
+] as const;
+
+/** Pre-allocated Set for O(1) branch-filterable event validation */
+export const BRANCH_FILTERABLE_EVENTS_SET: ReadonlySet<EventType> = new Set(
+  BRANCH_FILTERABLE_EVENTS
+);
+
+/**
  * Pending message cleanup interval (30 seconds)
  * How often to check for and remove stale pending messages
  */

--- a/src/github-app/event-processor.ts
+++ b/src/github-app/event-processor.ts
@@ -1,6 +1,6 @@
 import { isMatch } from "picomatch";
 
-import { EventType } from "../constants";
+import { BRANCH_FILTERABLE_EVENTS_SET, EventType } from "../constants";
 import {
   formatCreate,
   formatDelete,
@@ -70,6 +70,14 @@ export class EventProcessor {
   ) {
     if (logContext) {
       console.log(`Processing ${logContext}`);
+    }
+
+    // Validate branchContext is provided for branch-filterable events
+    const isBranchFilterable = BRANCH_FILTERABLE_EVENTS_SET.has(eventType);
+    if (isBranchFilterable && !branchContext) {
+      throw new Error(
+        `${eventType} is branch-filterable but no branchContext provided`
+      );
     }
 
     // Get subscribed channels for this repo (webhook mode only)


### PR DESCRIPTION
Add BRANCH_FILTERABLE_EVENTS constant to define which event types support branch filtering. Both event-processor.ts (webhooks) and polling-service.ts (polling) now use this constant:

- event-processor.ts: Throws if branch-filterable event missing branchContext
- polling-service.ts: Derives GitHub event type set and uses as gate

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced validation to ensure branch context is provided when required for applicable events.
  * Refined branch-filtering logic to apply selectively only to supported event types (pull requests, commits, CI, reviews, review comments, and branch events), improving filtering accuracy.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->