### PR TITLE
fix: add Events API specific actions to validation schemas

### DIFF
--- a/src/types/events-api.ts
+++ b/src/types/events-api.ts
@@ -42,7 +42,10 @@ function actionSchema<T extends readonly string[]>(
     .refine(
       (action): action is T[number] =>
         (actions as readonly string[]).includes(action),
-      { message: `Unknown ${eventType} action` }
+      {
+        error: issue =>
+          `Unknown ${eventType} action: "${String(issue.input)}". Expected one of: ${actions.join(", ")}`,
+      }
     );
 }
 


### PR DESCRIPTION
GitHub's Events API uses different action names than Webhooks API:
- PR: adds 'merged' action (webhooks uses 'closed' with merged flag)
- PR Review: adds 'created'/'updated' (webhooks uses 'submitted'/'edited')

Also improves error logging to show the actual action value on validation failure.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Unified action validation by introducing explicit per-event action sets for webhook events, improving consistency of event handling.

* **Bug Fixes**
  * Improved validation and error logging: messages now include event type, event ID (defaults to "unknown" if missing) and action when available, with clearer allowed-action feedback for invalid values.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->