### PR TITLE
feat: add PR/issue anchor dynamic updates

### DIFF
--- a/src/formatters/events-api.ts
+++ b/src/formatters/events-api.ts
@@ -10,7 +10,13 @@
 
 import type { GitHubPullRequest } from "../api/github-client";
 import type { GitHubEvent } from "../types/events-api";
-import { buildMessage, getPrEventEmoji, getPrEventHeader } from "./shared";
+import {
+  buildMessage,
+  getIssueEventEmoji,
+  getIssueEventHeader,
+  getPrEventEmoji,
+  getPrEventHeader,
+} from "./shared";
 
 /**
  * Format GitHub Events API events into human-readable messages
@@ -68,18 +74,10 @@ export function formatEvent(
 
       if (!issue) return "";
 
-      let emoji: string;
-      let header: string;
+      const emoji = getIssueEventEmoji(action);
+      const header = getIssueEventHeader(action);
 
-      if (action === "opened") {
-        emoji = "🐛";
-        header = "Issue Opened";
-      } else if (action === "closed") {
-        emoji = "✅";
-        header = "Issue Closed";
-      } else {
-        return "";
-      }
+      if (!emoji || !header) return "";
 
       return buildMessage({
         emoji,

--- a/src/formatters/shared.ts
+++ b/src/formatters/shared.ts
@@ -58,6 +58,7 @@ export function getPrEventEmoji(action: string, merged: boolean): string {
   if (action === "opened") return "🔔";
   if (action === "closed" && merged) return "✅";
   if (action === "closed" && !merged) return "❌";
+  if (action === "reopened") return "🔄";
   return "";
 }
 
@@ -68,5 +69,26 @@ export function getPrEventHeader(action: string, merged: boolean): string {
   if (action === "opened") return "Pull Request Opened";
   if (action === "closed" && merged) return "Pull Request Merged";
   if (action === "closed" && !merged) return "Pull Request Closed";
+  if (action === "reopened") return "Pull Request Reopened";
+  return "";
+}
+
+/**
+ * Get emoji for issue event based on action
+ */
+export function getIssueEventEmoji(action: string): string {
+  if (action === "opened") return "🐛";
+  if (action === "closed") return "✅";
+  if (action === "reopened") return "🔄";
+  return "";
+}
+
+/**
+ * Get header text for issue event based on action
+ */
+export function getIssueEventHeader(action: string): string {
+  if (action === "opened") return "Issue Opened";
+  if (action === "closed") return "Issue Closed";
+  if (action === "reopened") return "Issue Reopened";
   return "";
 }

--- a/src/formatters/webhook-events.ts
+++ b/src/formatters/webhook-events.ts
@@ -17,7 +17,13 @@ import type {
   WatchPayload,
   WorkflowRunPayload,
 } from "../types/webhooks";
-import { buildMessage, getPrEventEmoji, getPrEventHeader } from "./shared";
+import {
+  buildMessage,
+  getIssueEventEmoji,
+  getIssueEventHeader,
+  getPrEventEmoji,
+  getPrEventHeader,
+} from "./shared";
 
 /**
  * Extract a clean preview from markdown/HTML content
@@ -48,10 +54,10 @@ export function formatPullRequest(payload: PullRequestPayload): string {
 
   if (!emoji || !header) return "";
 
-  const metadata =
-    action === "opened"
-      ? [`📊 +${pull_request.additions || 0} -${pull_request.deletions || 0}`]
-      : undefined;
+  // Always include stats for anchor messages
+  const metadata = [
+    `📊 +${pull_request.additions || 0} -${pull_request.deletions || 0}`,
+  ];
 
   return buildMessage({
     emoji,
@@ -68,18 +74,10 @@ export function formatPullRequest(payload: PullRequestPayload): string {
 export function formatIssue(payload: IssuesPayload): string {
   const { action, issue, repository } = payload;
 
-  let emoji: string;
-  let header: string;
+  const emoji = getIssueEventEmoji(action);
+  const header = getIssueEventHeader(action);
 
-  if (action === "opened") {
-    emoji = "🐛";
-    header = "Issue Opened";
-  } else if (action === "closed") {
-    emoji = "✅";
-    header = "Issue Closed";
-  } else {
-    return "";
-  }
+  if (!emoji || !header) return "";
 
   return buildMessage({
     emoji,
@@ -163,7 +161,7 @@ export function formatWorkflowRun(payload: WorkflowRunPayload): string {
 
 export function formatIssueComment(
   payload: IssueCommentPayload,
-  isThreadReply?: boolean
+  isThreadReply: boolean
 ): string {
   const { action, issue, comment, repository } = payload;
 
@@ -195,7 +193,7 @@ export function formatIssueComment(
 
 export function formatPullRequestReview(
   payload: PullRequestReviewPayload,
-  isThreadReply?: boolean
+  isThreadReply: boolean
 ): string {
   const { action, review, pull_request, repository } = payload;
 
@@ -234,7 +232,7 @@ export function formatPullRequestReview(
 
 export function formatPullRequestReviewComment(
   payload: PullRequestReviewCommentPayload,
-  isThreadReply?: boolean
+  isThreadReply: boolean
 ): string {
   const { action, comment, pull_request, repository } = payload;
 

--- a/src/services/message-delivery-service.ts
+++ b/src/services/message-delivery-service.ts
@@ -212,7 +212,11 @@ export class MessageDeliveryService {
       spaceId,
       channelId,
       repoFullName,
-      ...entityContext,
+      githubEntityType,
+      githubEntityId,
+      parentType: entityContext.parentType,
+      parentNumber: entityContext.parentNumber,
+      githubUpdatedAt,
       townsMessageId: existingMessageId,
     });
 


### PR DESCRIPTION
When a PR or issue is edited, closed, or reopened:
- Update the anchor message to reflect the new state
- For close/reopen: post a thread reply before updating anchor

Other changes:
- Add handleAnchorEvent to consolidate PR/issue event handling
- Add reopened state support for PR and issue formatters
- Extract getIssueEventEmoji/Header to shared.ts
- Simplify branchContext parameter to just branch string
- Make isThreadReply parameter required
- Always include diff stats in PR anchor messages

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Support for "reopened" status for pull requests and issues with matching icons and headers.
  * Pull request messages now always include change statistics (additions/deletions).

* **Refactor**
  * Centralized and simplified event formatting and delivery logic for more consistent message output.
  * Thread-reply behavior standardized across comment and review messages, improving reply handling.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>
<!-- end of auto-generated comment: release notes by coderabbit.ai -->